### PR TITLE
Implemented size check for appropriate matmul, not comptime

### DIFF
--- a/src/Core/Tensor/TensorMath/op_gemm.zig
+++ b/src/Core/Tensor/TensorMath/op_gemm.zig
@@ -123,9 +123,15 @@ pub fn lean_gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(
         //for (actual_B_ptr.shape) |s| std.debug.print("{d} ", .{s});
     }
 
+    const vals_in_cache = std.atomic.cache_line / @sizeOf(T);
+    if(B.shape[B.shape.len-1] > vals_in_cache){
+        try op_mat_mul.lean_blocked_mat_mul(T, actual_A_ptr, actual_B_ptr, result);
+    } else {
+        try op_mat_mul.lean_mat_mul(T, actual_A_ptr, actual_B_ptr, result);
+    }
     // result = alpha * A * B
     //std.debug.print("\n  Performing matrix multiplication...", .{});
-    try op_mat_mul.lean_mat_mul(T, actual_A_ptr, actual_B_ptr, result);
+    
     //std.debug.print("\n  Applying alpha scaling...", .{});
     for (0..result.size) |i| {
         result.data[i] *= alpha;

--- a/src/Core/Tensor/TensorMath/op_mat_mul.zig
+++ b/src/Core/Tensor/TensorMath/op_mat_mul.zig
@@ -173,6 +173,75 @@ pub inline fn lean_mat_mul(comptime T: anytype, A: *const Tensor(T), B: *const T
 
 const CACHE_BLOCK_SIZE_BYTES: usize = std.atomic.cache_line;
 
+pub inline fn blocked_mat_mul(comptime T: anytype, A: *const Tensor(T), B: *const Tensor(T)) !Tensor(T) {
+    // std.debug.print("\nStarting matrix multiplication validation...\n", .{});
+
+    // The two tensors needs to have the same dimensions N
+    if (A.shape.len != B.shape.len) {
+        // std.debug.print("Error: Input tensors have different dimensions. A: {}, B: {}\n", .{ A.shape.len, B.shape.len });
+        return TensorMathError.InputTensorDifferentShape;
+    }
+
+    const dim_num = A.shape.len;
+
+    // The last dimension (number of cols) of A must be equal to the second last dimension (number of rows) of B
+    if (A.shape[dim_num - 1] != B.shape[dim_num - 2]) {
+        // std.debug.print("Error: Incompatible matrix dimensions for multiplication. A[{}]={}, B[{}]={}\n", .{ dim_num - 1, A.shape[dim_num - 1], dim_num - 2, B.shape[dim_num - 2] });
+        return TensorMathError.InputTensorsWrongShape;
+    }
+
+    // The input tensors must have at least 2 dimensions
+    if (dim_num < 2) {
+        // std.debug.print("Error: Input tensors must have at least 2 dimensions. Got: {}\n", .{dim_num});
+        return TensorMathError.InputTensorsWrongShape;
+    }
+
+    // Create output tensor
+
+    const M = A.shape[dim_num - 2];
+    const N = B.shape[dim_num - 1];
+    const K = A.shape[dim_num - 1];
+
+    // Check if the input tensors are empty
+    if (M * N == 0 or K == 0) {
+        // std.debug.print("Error: Empty input tensors. M={}, N={}, K={}\n", .{ M, N, K });
+        return TensorMathError.InputTensorsWrongShape;
+    }
+
+    // std.debug.print("Validation passed, proceeding with multiplication\n", .{});
+
+    // Setup output tensor shape
+
+    const allocator = pkg_allocator;
+    var out_shape = try allocator.alloc(usize, dim_num);
+    defer allocator.free(out_shape);
+    errdefer allocator.free(out_shape);
+
+    // Copy all dimensions except the last two
+    for (0..(dim_num - 2)) |i| {
+        out_shape[i] = A.shape[i];
+    }
+
+    // Set the last two dimensions to the dimensions of the input tensors
+    out_shape[dim_num - 2] = A.shape[dim_num - 2];
+    out_shape[dim_num - 1] = B.shape[dim_num - 1];
+
+    // Create output tensor
+
+    var Y = try Tensor(T).fromShape(&allocator, out_shape);
+    errdefer Y.deinit();
+
+    // std.debug.print("Output tensor shape: ", .{});
+    // for (Y.shape) |dim| std.debug.print("{} ", .{dim});
+    // std.debug.print("\n", .{});
+
+    @memset(Y.data, 0);
+
+    try lean_blocked_mat_mul(T, A, B, &Y);
+
+    return Y;
+}
+
 //Loosely inspired from https://coffeebeforearch.github.io/2020/06/23/mmul.html
 //Easy to implement, works, loses some efficiency on non-square matrices or really large B matrices
 pub inline fn lean_blocked_mat_mul(comptime T: anytype, A: *const Tensor(T), B: *const Tensor(T), C: *const Tensor(T)) !void {


### PR DESCRIPTION
As of now with the matrices given to the functions, we cannot make the function comptime and leave out the other branch, performance impact should be negligible, but not the result we all desired.