### PR TITLE
Added the possibilty to input custom paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,16 @@ extern void setLogFunction(void (*log_function)(uint8_t *string));
   ```bash
   zig build codegen -Dmodel=model_name [-Dlog -Duser_tests=path/to/tests.json]
   ```
-
+  Optionally you can add:
+  - ```-Dmodel_path=path/to/model.onnx``` to manually select the path of your ONNX model (by default it's selected from ```datasets/model_name/model_name.onnx```)
+  - ```-Dgenerated_path=path/to/generated/``` to manually select where you want to save the generated code (by default it's saved in ```generated/model_name/```)
 - **Compile static library:**
   ```bash
   zig build lib -Dmodel=model_name -Dtarget=target_arch -Dcpu=specific_cpu
   ```
+  Optionally you can add:
+  - ```-Dgeneratedpath=path/to/generated/``` to manually select where your generated code is saved (by default it's selected from ```generated/model_name/```)
+  - ```-Doutput_path=path/to/output/``` to manually select where you want to save the static library (by default it's saved in ```zig-out/model_name/```)
 
 - **Generate onnx oneOperation models:**
   ```bash

--- a/src/CodeGen/main.zig
+++ b/src/CodeGen/main.zig
@@ -20,8 +20,7 @@ pub fn main() !void {
     const gpa_allocator = gpa.allocator();
 
     const model_name = codegen_options.model;
-    // Format model path according to model_name
-    const model_path = "datasets/models/" ++ model_name ++ "/" ++ model_name ++ ".onnx";
+    const model_path = codegen_options.model_path;
 
     var model = try onnx.parseFromFile(gpa_allocator, model_path);
     defer model.deinit(gpa_allocator);
@@ -29,7 +28,7 @@ pub fn main() !void {
     model.print();
 
     // Create the generated model directory if not present
-    const generated_path = "generated/" ++ model_name ++ "/";
+    const generated_path = codegen_options.generated_path;
     //const generated_path = "src/codeGen/";
     try std.fs.cwd().makePath(generated_path);
 


### PR DESCRIPTION
## Description

I modified the build.zig to accept different model path (for codegen input), generated path (for codegen output and build lib input) and output path (for build lib output). if the user doesn't select the options during zig build it falls back to the default folders datasets, generated, zig-out. updated readme with instructions on how to select path. this addition is needed for the zant server.

## Type of Change

Please mark the options that are relevant:

- [ ] Bug fix 🐛
- [x] New feature 🚀
- [x] Documentation update 📚
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests pass.