### PR TITLE
 Replace std.debug.print with std.log.* and custom log scopes in tests

### DIFF
--- a/benchmarks/matmul/macs_matmul.zig
+++ b/benchmarks/matmul/macs_matmul.zig
@@ -6,8 +6,6 @@ const TensMath = zant.core.tensor.math_standard;
 
 const CACHE_BLOCK_SIZE_BYTES: usize = std.atomic.cache_line;
 
-
-
 pub inline fn lean_mat_mul(comptime T: anytype, A: *const Tensor(T), B: *const Tensor(T), Y: *Tensor(T)) !void {
     const DEFAULT_VECTOR_WIDTH: usize = comptime (std.simd.suggestVectorLength(T) orelse 4);
     const dim_num = A.shape.len;
@@ -16,16 +14,16 @@ pub inline fn lean_mat_mul(comptime T: anytype, A: *const Tensor(T), B: *const T
     const N = B.shape[dim_num - 1];
     const K = A.shape[dim_num - 1];
 
-    // std.debug.print("\nMatrix multiplication dimensions: M={}, N={}, K={}\n", .{ M, N, K });
-    // std.debug.print("Input tensor A shape: ", .{});
-    // for (A.shape) |dim| std.debug.print("{} ", .{dim});
-    // std.debug.print("\nInput tensor B shape: ", .{});
-    // for (B.shape) |dim| std.debug.print("{} ", .{dim});
-    // std.debug.print("\n", .{});
+    // std.log.debug("\nMatrix multiplication dimensions: M={}, N={}, K={}\n", .{ M, N, K });
+    // std.log.debug("Input tensor A shape: ", .{});
+    // for (A.shape) |dim| std.log.debug("{} ", .{dim});
+    // std.log.debug("\nInput tensor B shape: ", .{});
+    // for (B.shape) |dim| std.log.debug("{} ", .{dim});
+    // std.log.debug("\n", .{});
 
-    // std.debug.print("Output tensor Y shape: ", .{});
-    // for (Y.shape) |dim| std.debug.print("{} ", .{dim});
-    // std.debug.print("\n", .{});
+    // std.log.debug("Output tensor Y shape: ", .{});
+    // for (Y.shape) |dim| std.log.debug("{} ", .{dim});
+    // std.log.debug("\n", .{});
 
     // SIMD vector type
     const Vec = @Vector(DEFAULT_VECTOR_WIDTH, T);
@@ -39,7 +37,7 @@ pub inline fn lean_mat_mul(comptime T: anytype, A: *const Tensor(T), B: *const T
     // Main matrix multiplication loop with SIMD
     var i: usize = 0;
     while (i < M) : (i += 1) {
-        // if (i % 100 == 0) std.debug.print("Processing row {}/{}\n", .{ i, M });
+        // if (i % 100 == 0) std.log.debug("Processing row {}/{}\n", .{ i, M });
         const row_offset = i * K;
         const out_offset = i * N;
 
@@ -88,5 +86,5 @@ pub inline fn lean_mat_mul(comptime T: anytype, A: *const Tensor(T), B: *const T
         }
     }
 
-    // std.debug.print("Matrix multiplication completed\n", .{});
+    // std.log.debug("Matrix multiplication completed\n", .{});
 }

--- a/build.zig
+++ b/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
         .arch_os_abi = target_str,
         .cpu_features = cpu_str,
     }) catch |err| {
-        std.debug.print("Error parsing target: {}\n", .{err});
+        std.log.scoped(.build).warn("Error parsing target: {}\n", .{err});
         return;
     };
 
@@ -69,7 +69,7 @@ pub fn build(b: *std.Build) void {
     // Name and path of the model
     const model_name_option = b.option([]const u8, "model", "Model name") orelse "mnist-8";
     const model_path_option = b.option([]const u8, "model_path", "Model path") orelse std.fmt.allocPrint(b.allocator, "datasets/models/{s}/{s}.onnx", .{ model_name_option, model_name_option }) catch |err| {
-        std.debug.print("Error allocating model path: {}\n", .{err});
+        std.log.scoped(.build).warn("Error allocating model path: {}\n", .{err});
         return;
     };
 
@@ -77,18 +77,18 @@ pub fn build(b: *std.Build) void {
     var generated_path_option = b.option([]const u8, "generated_path", "Generated path") orelse "";
     if (generated_path_option.len == 0) {
         generated_path_option = std.fmt.allocPrint(b.allocator, "generated/{s}/", .{model_name_option}) catch |err| {
-            std.debug.print("Error allocating generated path: {}\n", .{err});
+            std.log.scoped(.build).warn("Error allocating generated path: {}\n", .{err});
             return;
         };
     } else {
         if (!std.mem.endsWith(u8, generated_path_option, "/")) {
             generated_path_option = std.fmt.allocPrint(b.allocator, "{s}/", .{generated_path_option}) catch |err| {
-                std.debug.print("Error normalizing path: {}\n", .{err});
+                std.log.scoped(.build).warn("Error normalizing path: {}\n", .{err});
                 return;
             };
         }
         generated_path_option = std.fmt.allocPrint(b.allocator, "{s}{s}/", .{ generated_path_option, model_name_option }) catch |err| {
-            std.debug.print("Error allocating generated path: {}\n", .{err});
+            std.log.scoped(.build).warn("Error allocating generated path: {}\n", .{err});
             return;
         };
     }
@@ -122,7 +122,7 @@ pub fn build(b: *std.Build) void {
     // ************************************************ STATIC LIBRARY CREATION ************************************************
 
     const lib_model_path = std.fmt.allocPrint(b.allocator, "{s}lib_{s}.zig", .{ generated_path_option, model_name_option }) catch |err| {
-        std.debug.print("Error allocating lib model path: {}\n", .{err});
+        std.log.scoped(.build).warn("Error allocating lib model path: {}\n", .{err});
         return;
     };
 
@@ -145,16 +145,16 @@ pub fn build(b: *std.Build) void {
     if (output_path_option.len != 0) {
         if (!std.mem.endsWith(u8, output_path_option, "/")) {
             output_path_option = std.fmt.allocPrint(b.allocator, "{s}/", .{output_path_option}) catch |err| {
-                std.debug.print("Error normalizing path: {}\n", .{err});
+                std.log.scoped(.build).warn("Error normalizing path: {}\n", .{err});
                 return;
             };
         }
         const old_path = std.fmt.allocPrint(b.allocator, "zig-out/{s}/", .{model_name_option}) catch |err| {
-            std.debug.print("Error allocating old path: {}\n", .{err});
+            std.log.scoped(.build).warn("Error allocating old path: {}\n", .{err});
             return;
         };
         output_path_option = std.fmt.allocPrint(b.allocator, "{s}{s}/", .{ output_path_option, model_name_option }) catch |err| {
-            std.debug.print("Error allocating output path: {}\n", .{err});
+            std.log.scoped(.build).warn("Error allocating output path: {}\n", .{err});
             return;
         };
         const move_step = b.addSystemCommand(&[_][]const u8{
@@ -172,7 +172,7 @@ pub fn build(b: *std.Build) void {
 
     // Add test for generated library
     const test_model_path = std.fmt.allocPrint(b.allocator, "{s}test_{s}.zig", .{ generated_path_option, model_name_option }) catch |err| {
-        std.debug.print("Error allocating test model path: {}\n", .{err});
+        std.log.scoped(.build).warn("Error allocating test model path: {}\n", .{err});
         return;
     };
 
@@ -279,7 +279,7 @@ pub fn build(b: *std.Build) void {
 
     // Path to the generated model options file (moved here)
     const model_options_path = std.fmt.allocPrint(b.allocator, "{s}model_options.zig", .{generated_path_option}) catch |err| {
-        std.debug.print("Error allocating model options path: {}\n", .{err});
+        std.log.scoped(.build).warn("Error allocating model options path: {}\n", .{err});
         return;
     };
 

--- a/gui/sdl/sdl-standalone.zig
+++ b/gui/sdl/sdl-standalone.zig
@@ -240,7 +240,7 @@ fn runCodeGen() !void {
 
     const exit_status = try child.wait();
 
-    std.debug.print("\nExit Status: {}\n", .{exit_status});
+    std.log.info("\nExit Status: {}\n", .{exit_status});
     if (exit_status.Exited != 0) {
         page = .select_model;
     }
@@ -392,7 +392,7 @@ pub fn runLibGen() !void {
 
     const exit_status = try child.wait();
 
-    std.debug.print("\nExit Status: {}\n", .{exit_status});
+    std.log.info("\nExit Status: {}\n", .{exit_status});
     if (exit_status.Exited != 0) {
         page = .deploy_options;
     }

--- a/src/CodeGen/parameters.zig
+++ b/src/CodeGen/parameters.zig
@@ -106,7 +106,7 @@ pub inline fn wrtiteTensorShape(writer: std.fs.File.Writer, t: *TensorProto, nam
 /// - `t`: The tensor initializer.
 /// - `name`: The sanitized name of the tensor.
 pub inline fn writeArray(writer: std.fs.File.Writer, t: *TensorProto, name: []const u8) !void {
-    std.debug.print("\n[writeArray] Processing tensor: {s}, DataType: {any}", .{ name, t.data_type });
+    std.log.info("\n[writeArray] Processing tensor: {s}, DataType: {any}", .{ name, t.data_type });
 
     const dataTypeString: []const u8 = try utils.getTypeString(t.data_type);
 
@@ -146,13 +146,13 @@ pub inline fn writeArray(writer: std.fs.File.Writer, t: *TensorProto, name: []co
             .UINT8 => try writeRawData(writer, u8, raw),
             // TODO: Add other types as needed (e.g., FLOAT16, INT8, etc.)
             else => {
-                std.debug.print("\n[writeArray] Error: Unsupported raw data type {any} for tensor {s}", .{ t.data_type, name });
+                std.log.info("\n[writeArray] Error: Unsupported raw data type {any} for tensor {s}", .{ t.data_type, name });
                 std.log.err("Unsupported raw data type: {any}", .{t.data_type});
                 return error.DataTypeNotAvailable;
             },
         }
     } else {
-        std.debug.print("\n[writeArray] Error: No recognized data field (float_data, int_data, raw_data, etc.) found for tensor {s} with DataType {any}", .{ name, t.data_type });
+        std.log.info("\n[writeArray] Error: No recognized data field (float_data, int_data, raw_data, etc.) found for tensor {s} with DataType {any}", .{ name, t.data_type });
         return error.DataTypeNotAvailable;
     }
 

--- a/src/CodeGen/predict.zig
+++ b/src/CodeGen/predict.zig
@@ -126,7 +126,7 @@ inline fn write_graphSerialization(writer: std.fs.File.Writer) !void {
     } else {
         //check the output tensor name is the same
         if (!std.mem.eql(u8, globals.networkOutput.name, lastNode.outputs.items[0].name)) {
-            std.debug.print("\n\n   ERROR!!\n    DifferentOutputNames: \n      {s} vs {s}\n    LastNode:{s}\n\n", .{ globals.networkOutput.name, lastNode.outputs.items[0].name, lastNode.nodeProto.name.? });
+            std.log.warn("\n\n   ERROR!!\n    DifferentOutputNames: \n      {s} vs {s}\n    LastNode:{s}\n\n", .{ globals.networkOutput.name, lastNode.outputs.items[0].name, lastNode.nodeProto.name.? });
             lastNode.print(true);
             return error.DifferentOutputNames;
         }
@@ -334,7 +334,7 @@ fn write_OutputTensor(writer: std.fs.File.Writer, output: *ReadyTensor, size: i6
 
     // --- ADD CHECK FOR UNDEFINED TYPE ---
     if (output.dtype == .UNDEFINED) {
-        std.debug.print("\n\nCODEGEN ERROR: Attempted to generate output tensor '{s}' but its data type is UNDEFINED. Check ONNX graph analysis in globals.zig.\n\n", .{output.name});
+        std.log.warn("\n\nCODEGEN ERROR: Attempted to generate output tensor '{s}' but its data type is UNDEFINED. Check ONNX graph analysis in globals.zig.\n\n", .{output.name});
         return error.DataTypeNotAvailable; // Or a more specific error like CannotGenerateUndefinedType
     }
     // --- END CHECK ---

--- a/src/CodeGen/skeleton.zig
+++ b/src/CodeGen/skeleton.zig
@@ -33,7 +33,7 @@ pub fn writeZigFile(model_name: []const u8, model_path: []const u8, model: Model
     const lib_file_path = try std.fmt.allocPrint(allocator, "{s}lib_{s}.zig", .{ model_path, model_name });
     defer allocator.free(lib_file_path);
     var lib_file = try std.fs.cwd().createFile(lib_file_path, .{});
-    std.debug.print("\n .......... file created, path:{s}", .{lib_file_path});
+    std.log.info("\n .......... file created, path:{s}", .{lib_file_path});
     defer lib_file.close();
 
     const lib_writer = lib_file.writer();
@@ -42,7 +42,7 @@ pub fn writeZigFile(model_name: []const u8, model_path: []const u8, model: Model
     const params_file_path = try std.fmt.allocPrint(allocator, "{s}static_parameters.zig", .{model_path});
     defer allocator.free(params_file_path);
     var param_file = try std.fs.cwd().createFile(params_file_path, .{});
-    std.debug.print("\n .......... file created, path:{s}", .{params_file_path});
+    std.log.info("\n .......... file created, path:{s}", .{params_file_path});
     defer param_file.close();
 
     const param_writer = param_file.writer();

--- a/src/CodeGen/test_mnist-1.zig
+++ b/src/CodeGen/test_mnist-1.zig
@@ -7,7 +7,7 @@ const allocator = pkgAllocator.allocator;
 const model = @import("model_options.zig");
 
 test "Static Library - Random data Prediction Test" {
-    std.debug.print("\n     test: Static Library - {s} Random data Prediction Test\n", .{model.name});
+    std.log.scoped(.test_minst).info("\n     test: Static Library - {s} Random data Prediction Test\n", .{model.name});
 
     var input_shape = model.input_shape;
 
@@ -45,7 +45,7 @@ test "Static Library - Random data Prediction Test" {
     const LogFn = fn ([*c]u8) callconv(.C) void;
     const logFn: LogFn = struct {
         fn log(msg: [*c]u8) callconv(.C) void {
-            std.debug.print("{s}", .{msg});
+            std.log.scoped(.test_minst).debug("{s}", .{msg});
         }
     }.log;
 
@@ -60,11 +60,11 @@ test "Static Library - Random data Prediction Test" {
         &result,
     );
 
-    std.debug.print("\nPrediction done without erorrs:\n", .{});
+    std.log.scoped(.test_minst).info("\nPrediction done without erorrs:\n", .{});
 }
 
 test "Static Library - Wrong Input Shape" {
-    std.debug.print("\n     test: Static Library - {s} Wrong Input Shape\n", .{model.name});
+    std.log.scoped(.test_minst).info("\n     test: Static Library - {s} Wrong Input Shape\n", .{model.name});
 
     // Test with wrong input shape
 
@@ -112,7 +112,7 @@ test "Static Library - Wrong Input Shape" {
 }
 
 test "Static Library - Empty Input" {
-    std.debug.print("\n     test: Static Library - {s} Empty Input\n", .{model.name});
+    std.log.scoped(.test_minst).info("\n     test: Static Library - {s} Empty Input\n", .{model.name});
 
     // Test with empty input
     var input_data = [_]f32{};
@@ -128,7 +128,7 @@ test "Static Library - Empty Input" {
 }
 
 test "Static Library - Wrong Number of Dimensions" {
-    std.debug.print("\n     test: Static Library - {s} Wrong Number of Dimensions\n", .{model.name});
+    std.log.scoped(.test_minst).info("\n     test: Static Library - {s} Wrong Number of Dimensions\n", .{model.name});
 
     const model_input_shape = model.input_shape;
 
@@ -138,7 +138,7 @@ test "Static Library - Wrong Number of Dimensions" {
     }
 
     // Test with wrong number of dimensions
-    
+
     var input_shape = [_]u32{input_data_size}; // Should be 4D but only 1D
 
     var input_data = try allocator.alloc(f32, input_data_size);
@@ -162,7 +162,7 @@ test "Static Library - Wrong Number of Dimensions" {
 // TODO: Implement the following tests
 
 // test "Static Library - User Prediction Test" {
-//     std.debug.print("\n     test: Static Library - {s} User Prediction Test\n", .{model.name});
+//     std.log.scoped(.test_minst).info("\n     test: Static Library - {s} User Prediction Test\n", .{model.name});
 
 //     var input_shape = model.input_shape;
 
@@ -200,7 +200,7 @@ test "Static Library - Wrong Number of Dimensions" {
 //     const LogFn = fn ([*c]u8) callconv(.C) void;
 //     const logFn: LogFn = struct {
 //         fn log(msg: [*c]u8) callconv(.C) void {
-//             std.debug.print("{s}", .{msg});
+//             std.log.scoped(.test_minst).debug("{s}", .{msg});
 //         }
 //     }.log;
 
@@ -215,6 +215,6 @@ test "Static Library - Wrong Number of Dimensions" {
 //         &result,
 //     );
 
-//     std.debug.print("\nPrediction results:\n", .{});
-//     std.debug.print("{} ", .{result[0]});
+//     std.log.scoped(.test_minst).debug("\nPrediction results:\n", .{});
+//     std.log.scoped(.test_minst).debug("{} ", .{result[0]});
 // }

--- a/src/CodeGen/tests.zig
+++ b/src/CodeGen/tests.zig
@@ -55,7 +55,7 @@ pub fn writeTestFile(model_name: []const u8, model_path: []const u8) !void {
     const test_file_path = try std.fmt.allocPrint(allocator, "{s}test_{s}.zig", .{ model_path, model_name });
 
     try utils.copyFile("tests/CodeGen/test_model.template.zig", test_file_path);
-    std.debug.print("\n\nGenerated test file: {s}\n", .{test_file_path});
+    std.log.info("\n\nGenerated test file: {s}\n", .{test_file_path});
 
     // Copy user test file into the generated test file
     if (codegen_options.user_tests.len > 0) {
@@ -72,7 +72,7 @@ pub fn writeSlimTestFile(model_name: []const u8, model_path: []const u8) !void {
     const test_file_path = try std.fmt.allocPrint(allocator, "{s}test_{s}.zig", .{ model_path, model_name });
 
     try utils.copyFile("tests/CodeGen/test_model.slim.template.zig", test_file_path);
-    std.debug.print("\n\nGenerated test file: {s}\n", .{test_file_path});
+    std.log.info("\n\nGenerated test file: {s}\n", .{test_file_path});
 
     try writeModelOptionsFile(model_name, model_path);
 }

--- a/src/Core/Tensor/TensorMath/lib_activation_function_math/op_sigmoid.zig
+++ b/src/Core/Tensor/TensorMath/lib_activation_function_math/op_sigmoid.zig
@@ -27,20 +27,20 @@ pub inline fn sigmoid(comptime T: anytype, tensor: *Tensor(T)) !Tensor(T) {
 
 pub inline fn sigmoid_lean(comptime T: anytype, input_tensor: *Tensor(T), output_tensor: *Tensor(T)) !void {
     @setEvalBranchQuota(100000);
-    //std.debug.print("\n[DEBUG] sigmoid_lean:", .{});
-    //std.debug.print("\n  Input shape: ", .{});
-    //for (input_tensor.shape) |s| std.debug.print("{d} ", .{s});
+    //std.log.debug("\n[DEBUG] sigmoid_lean:", .{});
+    //std.log.debug("\n  Input shape: ", .{});
+    //for (input_tensor.shape) |s| std.log.debug("{d} ", .{s});
 
-    //std.debug.print("\n  Output shape: ", .{});
-    //for (output_tensor.shape) |s| std.debug.print("{d} ", .{s});
+    //std.log.debug("\n  Output shape: ", .{});
+    //for (output_tensor.shape) |s| std.log.debug("{d} ", .{s});
 
     //apply Sigmoid
     for (0..input_tensor.size) |i| {
         const input_val = input_tensor.data[i];
         output_tensor.data[i] = 1.0 / (1.0 + @exp(-input_val));
-        //std.debug.print("\n  sigmoid({d:.6}) = {d:.6}", .{ input_val, output_tensor.data[i] });
+        //std.log.debug("\n  sigmoid({d:.6}) = {d:.6}", .{ input_val, output_tensor.data[i] });
     }
-    //std.debug.print("\n[DEBUG] sigmoid_lean completed\n", .{});
+    //std.log.debug("\n[DEBUG] sigmoid_lean completed\n", .{});
 }
 
 pub fn sigmoid_backward(comptime T: anytype, gradient: *Tensor(T), act_forward_out: *Tensor(T)) !void {

--- a/src/Core/Tensor/TensorMath/lib_elementWise_math/op_addition.zig
+++ b/src/Core/Tensor/TensorMath/lib_elementWise_math/op_addition.zig
@@ -79,7 +79,7 @@ fn calculate_broadcasted_shape(alloc: *const std.mem.Allocator, shape1_in: []con
         if (shape1_padded[dim] != shape2_padded[dim] and shape1_padded[dim] != 1 and shape2_padded[dim] != 1) {
             // Need to free out_shape before returning error
             alloc.free(out_shape);
-            std.debug.print("Incompatible broadcast shapes at dim {}: {} vs {}\n", .{ dim, shape1_padded[dim], shape2_padded[dim] }); // DEBUG PRINT
+            std.log.warn("Incompatible broadcast shapes at dim {}: {} vs {}\n", .{ dim, shape1_padded[dim], shape2_padded[dim] }); // DEBUG PRINT
             return TensorMathError.IncompatibleBroadcastShapes;
         }
         out_shape[dim] = @max(shape1_padded[dim], shape2_padded[dim]);
@@ -128,9 +128,9 @@ pub fn sum_tensors(comptime inputType: anytype, comptime outputType: anytype, t1
 
 // --------- lean SUM
 pub inline fn lean_sum_tensors(comptime inputType: anytype, comptime outputType: anytype, t1: *const Tensor(inputType), t2: *const Tensor(inputType), outputTensor: *Tensor(outputType)) !void {
-    // std.debug.print("\nINFO: Summing tensors with sizes: {d}, {d}\n", .{ t1.size, t2.size }); // DEBUG PRINT
-    // std.debug.print("\nINFO: t1 shape: {any}, t2 shape: {any}\n", .{ t1.shape, t2.shape }); // DEBUG PRINT
-    // std.debug.print("\nINFO: outputTensor shape: {any}\n", .{outputTensor.shape}); // DEBUG PRINT
+    // std.log.debug("\nINFO: Summing tensors with sizes: {d}, {d}\n", .{ t1.size, t2.size }); // DEBUG PRINT
+    // std.log.debug("\nINFO: t1 shape: {any}, t2 shape: {any}\n", .{ t1.shape, t2.shape }); // DEBUG PRINT
+    // std.log.debug("\nINFO: outputTensor shape: {any}\n", .{outputTensor.shape}); // DEBUG PRINT
     // // Simple case: same size tensors
     if (t1.size == t2.size) {
         // Use unrolled loop for small sizes to avoid SIMD overhead
@@ -231,7 +231,7 @@ pub inline fn lean_sum_tensors(comptime inputType: anytype, comptime outputType:
         @memset(full_output_shape_slice[0..output_rank_diff], 1); // Pad with leading 1s
     }
     @memcpy(full_output_shape_slice[output_rank_diff..], outputTensor.shape);
-    // std.debug.print("DEBUG: Original output shape: {any}, Reconstructed full shape: {any}\\n", .{ outputTensor.shape, full_output_shape_slice });
+    // std.log.debug("DEBUG: Original output shape: {any}, Reconstructed full shape: {any}\\n", .{ outputTensor.shape, full_output_shape_slice });
     // --- END WORKAROUND ---
 
     // Calculate strides from right to left using the reconstructed full shape

--- a/src/Core/Tensor/TensorMath/lib_elementWise_math/op_multiplication.zig
+++ b/src/Core/Tensor/TensorMath/lib_elementWise_math/op_multiplication.zig
@@ -185,9 +185,9 @@ pub fn get_mul_output_shape(lhs: []const usize, rhs: []const usize) ![]usize {
         const dim2 = if (rank2 + i >= max_rank) rhs[rank2 + i - max_rank] else 1;
 
         if (dim1 != dim2 and dim1 != 1 and dim2 != 1) {
-            std.debug.print("Incompatible broadcast shapes: dim1={}, dim2={}, index={}\n", .{ dim1, dim2, i });
-            std.debug.print("lhs shape: {any}\n", .{lhs});
-            std.debug.print("rhs shape: {any}\n", .{rhs});
+            std.log.warn("Incompatible broadcast shapes: dim1={}, dim2={}, index={}\n", .{ dim1, dim2, i });
+            std.log.warn("lhs shape: {any}\n", .{lhs});
+            std.log.warn("rhs shape: {any}\n", .{rhs});
             return TensorMathError.IncompatibleBroadcastShapes;
         }
         out_shape[i] = @max(dim1, dim2);

--- a/src/Core/Tensor/TensorMath/lib_logical_math.zig
+++ b/src/Core/Tensor/TensorMath/lib_logical_math.zig
@@ -56,21 +56,21 @@ pub fn isSafe(comptime T: anytype, t: *Tensor(T)) !void {
 pub fn equal(comptime T: anytype, t1: *Tensor(T), t2: *Tensor(T)) bool {
     //same size
     if (t1.size != t2.size) {
-        std.debug.print("\n\n ERROR:WRONG SIZE t1.size:{} t2.size:{}", .{ t1.size, t2.size });
+        std.log.warn("\n\n ERROR:WRONG SIZE t1.size:{} t2.size:{}", .{ t1.size, t2.size });
         return false;
     }
 
     //same shape
     for (0..t1.shape.len) |i| {
         if (t1.shape[i] != t2.shape[i]) {
-            std.debug.print("\n\n ERROR: WRONG SHAPE t1.shape[{}]:{} t2.shape[{}]:{}", .{ i, t1.shape[i], i, t2.shape[i] });
+            std.log.warn("\n\n ERROR: WRONG SHAPE t1.shape[{}]:{} t2.shape[{}]:{}", .{ i, t1.shape[i], i, t2.shape[i] });
             return false;
         }
     }
 
     //same data
     if (!std.mem.eql(T, t1.data, t2.data)) {
-        std.debug.print("\n\n ERROR: WRONG DATA", .{});
+        std.log.warn("\n\n ERROR: WRONG DATA", .{});
         return false;
     }
 

--- a/src/Core/Tensor/TensorMath/lib_reduction_math.zig
+++ b/src/Core/Tensor/TensorMath/lib_reduction_math.zig
@@ -93,39 +93,39 @@ pub inline fn lean_reduce_mean(
     _: bool, // keepdims (unused since output shape is pre-determined)
     noop_with_empty_axes: bool,
 ) !void {
-    //std.debug.print("\n[DEBUG] lean_reduce_mean:", .{});
-    //std.debug.print("\n  Input tensor shape: ", .{});
-    //for (input_tensor.shape) |s| std.debug.print("{d} ", .{s});
-    //std.debug.print("\n  Output tensor shape: ", .{});
-    //for (output_tensor.shape) |s| std.debug.print("{d} ", .{s});
-    //std.debug.print("\n  Axes: ", .{});
+    //std.log.debug("\n[DEBUG] lean_reduce_mean:", .{});
+    //std.log.debug("\n  Input tensor shape: ", .{});
+    //for (input_tensor.shape) |s| std.log.debug("{d} ", .{s});
+    //std.log.debug("\n  Output tensor shape: ", .{});
+    //for (output_tensor.shape) |s| std.log.debug("{d} ", .{s});
+    //std.log.debug("\n  Axes: ", .{});
     //if (axes) |a| {
     //    if (a.len == 0) {
-    //        std.debug.print("empty", .{});
+    //        std.log.debug("empty", .{});
     //    } else {
-    //        for (a) |axis| std.debug.print("{d} ", .{axis});
+    //        for (a) |axis| std.log.debug("{d} ", .{axis});
     //    }
     //} else {
-    //    std.debug.print("null", .{});
+    //    std.log.debug("null", .{});
     //}
-    //std.debug.print("\n  noop_with_empty_axes: {}", .{noop_with_empty_axes});
+    //std.log.debug("\n  noop_with_empty_axes: {}", .{noop_with_empty_axes});
 
     // Handle empty axes case
     if (axes == null or axes.?.len == 0) {
         if (noop_with_empty_axes) {
-            //std.debug.print("\n  Performing identity operation (noop)", .{});
+            //std.log.debug("\n  Performing identity operation (noop)", .{});
             // Act as identity operation
             @memcpy(output_tensor.data, input_tensor.data);
             return;
         }
         // Reduce over all dimensions
-        //std.debug.print("\n  Reducing over all dimensions", .{});
+        //std.log.debug("\n  Reducing over all dimensions", .{});
         var sum: T = 0;
         for (input_tensor.data) |val| {
             sum += val;
         }
         output_tensor.data[0] = sum / @as(T, @floatFromInt(input_tensor.size));
-        //std.debug.print("\n  Final result (all dims): {d}", .{output_tensor.data[0]});
+        //std.log.debug("\n  Final result (all dims): {d}", .{output_tensor.data[0]});
         return;
     }
 
@@ -137,7 +137,7 @@ pub inline fn lean_reduce_mean(
         else
             axis;
         if (abs_axis < 0 or abs_axis >= input_tensor.shape.len) {
-            //std.debug.print("\n  Error: Axis {d} out of bounds for tensor of rank {d}", .{ axis, input_tensor.shape.len });
+            //std.log.debug("\n  Error: Axis {d} out of bounds for tensor of rank {d}", .{ axis, input_tensor.shape.len });
             return TensorMathError.InvalidAxes;
         }
     }
@@ -146,13 +146,13 @@ pub inline fn lean_reduce_mean(
     var actual_axes = try pkg_allocator.alloc(usize, axes.?.len);
     defer pkg_allocator.free(actual_axes);
 
-    //std.debug.print("\n  Converting axes to positive indices:", .{});
+    //std.log.debug("\n  Converting axes to positive indices:", .{});
     for (axes.?, 0..) |axis, i| {
         actual_axes[i] = if (axis < 0)
             @intCast(@as(i64, @intCast(input_tensor.shape.len)) + axis)
         else
             @intCast(axis);
-        //std.debug.print("\n    axis {d} -> {d}", .{ axis, actual_axes[i] });
+        //std.log.debug("\n    axis {d} -> {d}", .{ axis, actual_axes[i] });
     }
 
     // Calculate the size of dimensions being reduced
@@ -160,7 +160,7 @@ pub inline fn lean_reduce_mean(
     for (actual_axes) |axis| {
         reduce_size *= input_tensor.shape[axis];
     }
-    //std.debug.print("\n  Total elements to reduce per output: {d}", .{reduce_size});
+    //std.log.debug("\n  Total elements to reduce per output: {d}", .{reduce_size});
 
     // Initialize output values to 0
     @memset(output_tensor.data, 0);
@@ -179,7 +179,7 @@ pub inline fn lean_reduce_mean(
 
     // For each output element
     for (0..output_tensor.size) |out_idx| {
-        //std.debug.print("\n\nProcessing output element {d}:", .{out_idx});
+        //std.log.debug("\n\nProcessing output element {d}:", .{out_idx});
 
         // Calculate input indices for non-reduced dimensions
         var remaining = out_idx;
@@ -219,7 +219,7 @@ pub inline fn lean_reduce_mean(
             remaining %= output_strides[dim_idx];
 
             base_idx += current_dim * dim_stride;
-            //std.debug.print("\n  Non-reduced dim {d}: current_dim={d}, stride={d}, base_idx={d}", .{ dim, current_dim, dim_stride, base_idx });
+            //std.log.debug("\n  Non-reduced dim {d}: current_dim={d}, stride={d}, base_idx={d}", .{ dim, current_dim, dim_stride, base_idx });
             non_reduced_dim += 1;
             output_dim += 1;
         }
@@ -228,7 +228,7 @@ pub inline fn lean_reduce_mean(
         var sum: T = 0;
         const count = reduce_size;
 
-        //std.debug.print("\n  Reduction info: count={d}, base_idx={d}", .{ count, base_idx });
+        //std.log.debug("\n  Reduction info: count={d}, base_idx={d}", .{ count, base_idx });
 
         // Calculate the size and stride for each reduced dimension
         var reduced_sizes = try pkg_allocator.alloc(usize, actual_axes.len);
@@ -241,7 +241,7 @@ pub inline fn lean_reduce_mean(
             const rev_idx = actual_axes.len - 1 - axis_idx;
             reduced_sizes[rev_idx] = input_tensor.shape[axis];
             reduced_strides[rev_idx] = input_strides[axis];
-            //std.debug.print("\n  Reduced axis {d}: size={d}, stride={d}", .{ axis, input_tensor.shape[axis], input_strides[axis] });
+            //std.log.debug("\n  Reduced axis {d}: size={d}, stride={d}", .{ axis, input_tensor.shape[axis], input_strides[axis] });
         }
 
         // Iterate over all combinations of reduced dimensions
@@ -259,11 +259,11 @@ pub inline fn lean_reduce_mean(
 
             sum += input_tensor.data[temp_idx];
             //if (idx < 5 or idx > count - 5) {
-            //std.debug.print("\n    idx={d}: temp_idx={d}, value={d}", .{ idx, temp_idx, input_tensor.data[temp_idx] });
+            //std.log.debug("\n    idx={d}: temp_idx={d}, value={d}", .{ idx, temp_idx, input_tensor.data[temp_idx] });
             //}
         }
 
-        //std.debug.print("\n  Final sum={d}, mean={d}", .{ sum, sum / @as(T, @floatFromInt(count)) });
+        //std.log.debug("\n  Final sum={d}, mean={d}", .{ sum, sum / @as(T, @floatFromInt(count)) });
         output_tensor.data[out_idx] = sum / @as(T, @floatFromInt(count));
     }
 }

--- a/src/Core/Tensor/TensorMath/lib_shape_math/op_concatenate.zig
+++ b/src/Core/Tensor/TensorMath/lib_shape_math/op_concatenate.zig
@@ -222,31 +222,31 @@ pub fn concatenate_lean(comptime T: type, allocator: *const std.mem.Allocator, t
 pub fn get_concatenate_output_shape(tensors: []const []const usize, axis: isize) ![]usize {
     // Ensure there is at least one tensor to concatenate
     if (tensors.len == 0) return TensorMathError.EmptyTensorList;
-    // std.debug.print("\n[DEBUG] get_concatenate_output_shape - Starting concatenation", .{});
-    // std.debug.print("\n[DEBUG] tensors: {any}", .{tensors});
-    // std.debug.print("\n[DEBUG] axis: {d}", .{axis});
+    // std.log.debug("\n get_concatenate_output_shape - Starting concatenation", .{});
+    // std.log.debug("\n tensors: {any}", .{tensors});
+    // std.log.debug("\n axis: {d}", .{axis});
 
     // Find the maximum rank among all tensors
     var max_rank: usize = 0;
     for (tensors) |tensor| {
         max_rank = @max(max_rank, tensor.len);
     }
-    // std.debug.print("\n[DEBUG] max_rank: {}", .{max_rank});
+    // std.log.debug("\n max_rank: {}", .{max_rank});
 
     // Handle negative axis values (numpy style)
     var concat_axis = axis;
     if (concat_axis < 0) {
         concat_axis += @as(isize, @intCast(max_rank));
-        // std.debug.print("\n[DEBUG] normalized negative axis to: {}", .{concat_axis});
+        // std.log.debug("\n normalized negative axis to: {}", .{concat_axis});
     }
 
     if (concat_axis < 0 or concat_axis >= @as(isize, @intCast(max_rank))) {
-        std.debug.print("\n[DEBUG] axis out of bounds: {} (max_rank: {})", .{ concat_axis, max_rank });
+        std.log.debug("\n axis out of bounds: {} (max_rank: {})", .{ concat_axis, max_rank });
         return TensorError.AxisOutOfBounds;
     }
 
     const concat_axis_usize = @as(usize, @intCast(concat_axis));
-    // std.debug.print("\n[DEBUG] concat_axis_usize: {}", .{concat_axis_usize});
+    // std.log.debug("\n concat_axis_usize: {}", .{concat_axis_usize});
 
     // Create broadcasted shapes for all tensors
     var broadcasted_shapes = try pkg_allocator.alloc([]usize, tensors.len);
@@ -281,24 +281,24 @@ pub fn get_concatenate_output_shape(tensors: []const []const usize, axis: isize)
                 broadcasted_shapes[i][j] = dim;
             }
         }
-        // std.debug.print("\n[DEBUG] Broadcasted shape[{}]: {any}", .{ i, broadcasted_shapes[i] });
+        // std.log.debug("\n Broadcasted shape[{}]: {any}", .{ i, broadcasted_shapes[i] });
     }
 
     // Validate that all tensors have matching shapes except along the concatenation axis
     for (broadcasted_shapes, 0..) |shape, i| {
         for (0..max_rank) |d| {
             if (d != concat_axis_usize and shape[d] != broadcasted_shapes[0][d]) {
-                std.debug.print("\n[DEBUG] Shape mismatch at dim {}: shape[{}][{}] = {} != shape[0][{}] = {}", .{ d, i, d, shape[d], d, broadcasted_shapes[0][d] });
+                std.log.debug("\n Shape mismatch at dim {}: shape[{}][{}] = {} != shape[0][{}] = {}", .{ d, i, d, shape[d], d, broadcasted_shapes[0][d] });
                 return TensorError.MismatchedShape;
             }
         }
     }
 
     // Calculate the new shape after concatenation
-    // std.debug.print("\n[DEBUG] Allocating new shape array of size {}", .{max_rank});
+    // std.log.debug("\n Allocating new shape array of size {}", .{max_rank});
     var new_shape = try pkg_allocator.alloc(usize, max_rank);
     errdefer {
-        std.debug.print("\n[DEBUG] Error occurred, freeing new_shape", .{});
+        std.log.debug("\n Error occurred, freeing new_shape", .{});
         pkg_allocator.free(new_shape);
     }
 
@@ -309,10 +309,10 @@ pub fn get_concatenate_output_shape(tensors: []const []const usize, axis: isize)
                 sum += shape[d];
             }
             new_shape[d] = sum;
-            // std.debug.print("\n[DEBUG] Concatenation dimension {}: sum = {}", .{ d, sum });
+            // std.log.debug("\n Concatenation dimension {}: sum = {}", .{ d, sum });
         } else {
             new_shape[d] = broadcasted_shapes[0][d];
-            // std.debug.print("\n[DEBUG] Non-concatenation dimension {}: {}", .{ d, new_shape[d] });
+            // std.log.debug("\n Non-concatenation dimension {}: {}", .{ d, new_shape[d] });
         }
     }
 
@@ -322,6 +322,6 @@ pub fn get_concatenate_output_shape(tensors: []const []const usize, axis: isize)
     }
     pkg_allocator.free(broadcasted_shapes);
 
-    // std.debug.print("\n[DEBUG] Final output shape: {any}", .{new_shape});
+    // std.log.debug("\n Final output shape: {any}", .{new_shape});
     return new_shape;
 }

--- a/src/Core/Tensor/TensorMath/lib_shape_math/op_gather.zig
+++ b/src/Core/Tensor/TensorMath/lib_shape_math/op_gather.zig
@@ -64,7 +64,7 @@ pub fn lean_gather(comptime T: anytype, data: *Tensor(T), indices: *Tensor(usize
         inner_size *= data.shape[i];
     }
 
-    //std.debug.print("[GATHER DEBUG] Outer size: {d}, Inner size: {d}, Indices size: {d}\n", .{ outer_size, inner_size, indices_size });
+    //std.log.debug("[GATHER DEBUG] Outer size: {d}, Inner size: {d}, Indices size: {d}\n", .{ outer_size, inner_size, indices_size });
 
     // Iterate over each "outer" segment
     for (0..outer_size) |outer_idx| {
@@ -79,7 +79,7 @@ pub fn lean_gather(comptime T: anytype, data: *Tensor(T), indices: *Tensor(usize
             // Calculate the starting offset in the output tensor
             const output_offset = (outer_idx * indices_size + idx) * inner_size;
 
-            //std.debug.print("[GATHER DEBUG] Outer idx: {d}, Gather idx: {d}, Data offset: {d}, Output offset: {d}\n", .{ outer_idx, gather_idx, data_offset, output_offset });
+            //std.log.debug("[GATHER DEBUG] Outer idx: {d}, Gather idx: {d}, Data offset: {d}, Output offset: {d}\n", .{ outer_idx, gather_idx, data_offset, output_offset });
 
             // Perform the data copy using std.mem.copy
             @memcpy(output.data[output_offset .. output_offset + inner_size], data.data[data_offset .. data_offset + inner_size]);

--- a/src/Core/Tensor/TensorMath/lib_shape_math/op_padding.zig
+++ b/src/Core/Tensor/TensorMath/lib_shape_math/op_padding.zig
@@ -30,7 +30,7 @@ pub fn addPaddingAndDilation(
 
     const new_row_numb = t.shape[dim - 2] + upPadding + downPadding + verticalDil * (t.shape[dim - 2] - 1);
     const new_col_numb = t.shape[dim - 1] + leftPadding + rightPadding + horizontalDil * (t.shape[dim - 1] - 1);
-    //std.debug.print("\n new_row_numb: {} new_col_numb:{}", .{ new_row_numb, new_col_numb });
+    //std.log.debug("\n new_row_numb: {} new_col_numb:{}", .{ new_row_numb, new_col_numb });
 
     //compute new shape
     const new_shape = try t.allocator.alloc(usize, dim);

--- a/src/Core/Tensor/TensorMath/lib_shape_math/op_reshape.zig
+++ b/src/Core/Tensor/TensorMath/lib_shape_math/op_reshape.zig
@@ -13,7 +13,7 @@ const pkg_allocator = zant.utils.allocator.allocator;
 /// At most one dimension of the new shape can be -1. In this case, the value is inferred from the size of the tensor and the remaining dimensions.
 /// A dimension could also be 0, in which case the actual dimension value is unchanged (i.e. taken from the input tensor).
 pub fn reshape_f32(comptime T: anytype, input: *Tensor(T), newShape: []f32, allowZero: ?bool) !Tensor(T) {
-    //std.debug.print("\n[RESHAPE_F32] Input shape: {any}, newShape: {any}\n", .{ input.shape, newShape });
+    //std.log.debug("\n[RESHAPE_F32] Input shape: {any}, newShape: {any}\n", .{ input.shape, newShape });
 
     // Create output tensor with the same size as input but with new shape length
     var temp_shape = try pkg_allocator.alloc(usize, newShape.len);
@@ -25,7 +25,7 @@ pub fn reshape_f32(comptime T: anytype, input: *Tensor(T), newShape: []f32, allo
         temp_shape[i] = 1;
     }
 
-    //std.debug.print("[RESHAPE_F32] Temp shape: {any}\n", .{temp_shape});
+    //std.log.debug("[RESHAPE_F32] Temp shape: {any}\n", .{temp_shape});
 
     var output = try Tensor(T).fromShape(&pkg_allocator, temp_shape);
     errdefer output.deinit();
@@ -33,7 +33,7 @@ pub fn reshape_f32(comptime T: anytype, input: *Tensor(T), newShape: []f32, allo
     // Let reshape_lean handle the actual reshaping logic
     try reshape_lean_f32(T, input, newShape, allowZero, &output);
 
-    //std.debug.print("[RESHAPE_F32] Output shape: {any}, size: {}\n", .{ output.shape, output.size });
+    //std.log.debug("[RESHAPE_F32] Output shape: {any}, size: {}\n", .{ output.shape, output.size });
     return output;
 }
 
@@ -42,7 +42,7 @@ pub fn reshape_f32(comptime T: anytype, input: *Tensor(T), newShape: []f32, allo
 /// At most one dimension of the new shape can be -1. In this case, the value is inferred from the size of the tensor and the remaining dimensions.
 /// A dimension could also be 0, in which case the actual dimension value is unchanged (i.e. taken from the input tensor).
 pub fn reshape(comptime T: anytype, input: *Tensor(T), newShape: []const isize, allowZero: ?bool) !Tensor(T) {
-    //std.debug.print("\n[RESHAPE] Input shape: {any}, newShape: {any}\n", .{ input.shape, newShape });
+    //std.log.debug("\n[RESHAPE] Input shape: {any}, newShape: {any}\n", .{ input.shape, newShape });
 
     // Create output tensor with the same size as input but with new shape length
     var temp_shape = try pkg_allocator.alloc(usize, newShape.len);
@@ -54,7 +54,7 @@ pub fn reshape(comptime T: anytype, input: *Tensor(T), newShape: []const isize, 
         temp_shape[i] = 1;
     }
 
-    //std.debug.print("[RESHAPE] Temp shape: {any}\n", .{temp_shape});
+    //std.log.debug("[RESHAPE] Temp shape: {any}\n", .{temp_shape});
 
     var output = try Tensor(T).fromShape(&pkg_allocator, temp_shape);
     errdefer output.deinit();
@@ -62,13 +62,13 @@ pub fn reshape(comptime T: anytype, input: *Tensor(T), newShape: []const isize, 
     // Let reshape_lean handle the actual reshaping logic
     try reshape_lean(T, input, newShape, allowZero, &output);
 
-    //std.debug.print("[RESHAPE] Output shape: {any}, size: {}\n", .{ output.shape, output.size });
+    //std.log.debug("[RESHAPE] Output shape: {any}, size: {}\n", .{ output.shape, output.size });
     return output;
 }
 
 /// lean version of the reshape function for f32 shape arrays
 pub fn reshape_lean_f32(comptime T: anytype, input: *Tensor(T), newShape: []f32, allowZero: ?bool, output: *Tensor(T)) !void {
-    //std.debug.print("\n[RESHAPE_LEAN_F32] Input shape: {any}, newShape: {any}\n", .{ input.shape, newShape });
+    //std.log.debug("\n[RESHAPE_LEAN_F32] Input shape: {any}, newShape: {any}\n", .{ input.shape, newShape });
     _ = allowZero;
 
     // Create a copy of newShape that we can modify
@@ -85,14 +85,14 @@ pub fn reshape_lean_f32(comptime T: anytype, input: *Tensor(T), newShape: []f32,
     for (newShape, 0..) |dim, i| {
         if (dim == 0) {
             if (i >= input.shape.len) {
-                //std.debug.print("[RESHAPE_LEAN_F32] Error: Invalid input - dim is 0 but index {} >= input shape len {}\n", .{ i, input.shape.len });
+                //std.log.debug("[RESHAPE_LEAN_F32] Error: Invalid input - dim is 0 but index {} >= input shape len {}\n", .{ i, input.shape.len });
                 return TensorError.InvalidInput;
             }
             modified_shape[i] = input.shape[i];
             known_dims_product *= input.shape[i];
         } else if (dim < 0) {
             if (neg_one_index != null) {
-                //std.debug.print("[RESHAPE_LEAN_F32] Error: Invalid input - multiple negative dimensions\n", .{});
+                //std.log.debug("[RESHAPE_LEAN_F32] Error: Invalid input - multiple negative dimensions\n", .{});
                 return TensorError.InvalidInput;
             }
             neg_one_index = i;
@@ -103,14 +103,14 @@ pub fn reshape_lean_f32(comptime T: anytype, input: *Tensor(T), newShape: []f32,
         }
     }
 
-    //std.debug.print("[RESHAPE_LEAN_F32] Modified shape before inference: {any}, neg_one_index: {?}, known_dims_product: {}\n", .{ modified_shape, neg_one_index, known_dims_product });
+    //std.log.debug("[RESHAPE_LEAN_F32] Modified shape before inference: {any}, neg_one_index: {?}, known_dims_product: {}\n", .{ modified_shape, neg_one_index, known_dims_product });
 
     try reshape_lean_common(T, input, modified_shape, neg_one_index, known_dims_product, output);
 }
 
 /// lean version of the reshape function for usize shape arrays
 pub fn reshape_lean(comptime T: anytype, input: *Tensor(T), newShape: []const isize, allowZero: ?bool, output: *Tensor(T)) !void {
-    //std.debug.print("\n[RESHAPE_LEAN] Input shape: {any}, newShape: {any}\n", .{ input.shape, newShape });
+    //std.log.debug("\n[RESHAPE_LEAN] Input shape: {any}, newShape: {any}\n", .{ input.shape, newShape });
     _ = allowZero;
 
     // Create a copy of newShape that we can modify
@@ -127,20 +127,20 @@ pub fn reshape_lean(comptime T: anytype, input: *Tensor(T), newShape: []const is
     for (newShape, 0..) |dim, i| {
         if (dim == 0) {
             if (i >= input.shape.len) {
-                //std.debug.print("[RESHAPE_LEAN] Error: Invalid input - dim is 0 but index {} >= input shape len {}\n", .{ i, input.shape.len });
+                //std.log.debug("[RESHAPE_LEAN] Error: Invalid input - dim is 0 but index {} >= input shape len {}\n", .{ i, input.shape.len });
                 return TensorError.InvalidInput;
             }
             modified_shape[i] = input.shape[i];
             known_dims_product *= input.shape[i];
         } else if (dim == -1) {
             if (neg_one_index != null) {
-                //std.debug.print("[RESHAPE_LEAN] Error: Invalid input - multiple negative dimensions\n", .{});
+                //std.log.debug("[RESHAPE_LEAN] Error: Invalid input - multiple negative dimensions\n", .{});
                 return TensorError.InvalidInput;
             }
             neg_one_index = i;
             modified_shape[i] = 1; // Temporary value, will be updated later
         } else if (dim < 0) {
-            //std.debug.print("[RESHAPE_LEAN] Error: Invalid input - negative dimension other than -1\n", .{});
+            //std.log.debug("[RESHAPE_LEAN] Error: Invalid input - negative dimension other than -1\n", .{});
             return TensorError.InvalidInput;
         } else {
             modified_shape[i] = @intCast(dim);
@@ -148,7 +148,7 @@ pub fn reshape_lean(comptime T: anytype, input: *Tensor(T), newShape: []const is
         }
     }
 
-    //std.debug.print("[RESHAPE_LEAN] Modified shape before inference: {any}, neg_one_index: {?}, known_dims_product: {}\n", .{ modified_shape, neg_one_index, known_dims_product });
+    //std.log.debug("[RESHAPE_LEAN] Modified shape before inference: {any}, neg_one_index: {?}, known_dims_product: {}\n", .{ modified_shape, neg_one_index, known_dims_product });
 
     try reshape_lean_common(T, input, modified_shape, neg_one_index, known_dims_product, output);
 }
@@ -159,7 +159,7 @@ pub fn get_reshape_output_shape(input_shape: []const usize, new_shape_spec: []co
     var input_size: usize = 1;
     for (input_shape) |dim| {
         input_size = std.math.mul(usize, input_size, dim) catch |err| {
-            std.debug.print("Error calculating input size (overflow?): {any}\n", .{err});
+            std.log.warn("Error calculating input size (overflow?): {any}\n", .{err});
             return TensorMathError.Overflow; // Or InvalidDimensions
         };
     }
@@ -199,7 +199,7 @@ pub fn get_reshape_output_shape(input_shape: []const usize, new_shape_spec: []co
                 // Multiply known_dims_product only if the copied dimension is non-zero
                 if (input_shape[i] != 0) {
                     known_dims_product = std.math.mul(usize, known_dims_product, input_shape[i]) catch |err| {
-                        std.debug.print("Error calculating known_dims_product (copied dim): {any}\n", .{err});
+                        std.log.warn("Error calculating known_dims_product (copied dim): {any}\n", .{err});
                         return TensorMathError.Overflow;
                     };
                 } else {
@@ -222,7 +222,7 @@ pub fn get_reshape_output_shape(input_shape: []const usize, new_shape_spec: []co
             output_shape[i] = @intCast(dim_spec);
             if (output_shape[i] != 0) {
                 known_dims_product = std.math.mul(usize, known_dims_product, output_shape[i]) catch |err| {
-                    std.debug.print("Error calculating known_dims_product (positive dim): {any}\n", .{err});
+                    std.log.warn("Error calculating known_dims_product (positive dim): {any}\n", .{err});
                     return TensorMathError.Overflow;
                 };
             } else {
@@ -263,7 +263,7 @@ pub fn get_reshape_output_shape(input_shape: []const usize, new_shape_spec: []co
     var output_size: usize = 1;
     for (output_shape) |dim| {
         output_size = std.math.mul(usize, output_size, dim) catch |err| {
-            std.debug.print("Error calculating output size (overflow?): {any}\n", .{err});
+            std.log.warn("Error calculating output size (overflow?): {any}\n", .{err});
             // Don't free output_shape here, the errdefer above will handle it.
             return TensorMathError.Overflow; // Or InvalidDimensions
         };

--- a/src/Core/Tensor/TensorMath/lib_shape_math/op_resize.zig
+++ b/src/Core/Tensor/TensorMath/lib_shape_math/op_resize.zig
@@ -46,11 +46,11 @@ pub fn resize(comptime T: type, t: *Tensor(T), comptime mode: []const u8, scales
 
 //resize lean
 pub fn rezise_lean(comptime T: type, t: *Tensor(T), comptime mode: []const u8, scales: ?[]const f32, sizes: ?[]const usize, coordinate_transformation_mode: []const u8, output_tensor: *Tensor(T)) !void {
-    std.debug.print("rezise_lean\n", .{});
-    std.debug.print("mode: {s}\n", .{mode});
-    std.debug.print("scales: {any}\n", .{scales});
-    std.debug.print("sizes: {any}\n", .{sizes});
-    std.debug.print("coordinate_transformation_mode: {s}\n", .{coordinate_transformation_mode});
+    std.log.debug("rezise_lean\n", .{});
+    std.log.debug("mode: {s}\n", .{mode});
+    std.log.debug("scales: {any}\n", .{scales});
+    std.log.debug("sizes: {any}\n", .{sizes});
+    std.log.debug("coordinate_transformation_mode: {s}\n", .{coordinate_transformation_mode});
 
     // Perform interpolation based on mode
     if (std.mem.eql(u8, mode, "nearest")) {

--- a/src/Core/Tensor/TensorMath/lib_shape_math/op_slice.zig
+++ b/src/Core/Tensor/TensorMath/lib_shape_math/op_slice.zig
@@ -115,12 +115,12 @@ pub fn lean_slice_onnx(comptime T: type, input: *Tensor(T), starts: []const i64,
 
 /// Calculate the output shape of a slice operation without performing the slice
 pub fn get_slice_output_shape(input_shape: []const usize, starts: []const i64, ends: []const i64, axes: ?[]const i64, steps: ?[]const i64) ![]usize {
-    std.debug.print("\n[DEBUG] get_slice_output_shape input:", .{});
-    std.debug.print("\n  input_shape: {any}", .{input_shape});
-    std.debug.print("\n  starts: {any}", .{starts});
-    std.debug.print("\n  ends: {any}", .{ends});
-    std.debug.print("\n  axes: {any}", .{axes});
-    std.debug.print("\n  steps: {any}", .{steps});
+    std.log.debug("\n[DEBUG] get_slice_output_shape input:", .{});
+    std.log.debug("\n  input_shape: {any}", .{input_shape});
+    std.log.debug("\n  starts: {any}", .{starts});
+    std.log.debug("\n  ends: {any}", .{ends});
+    std.log.debug("\n  axes: {any}", .{axes});
+    std.log.debug("\n  steps: {any}", .{steps});
 
     // Validate input lengths
     if (starts.len != ends.len) return TensorError.InvalidSliceIndices;
@@ -146,10 +146,10 @@ pub fn get_slice_output_shape(input_shape: []const usize, starts: []const i64, e
         actual_steps[i] = 1;
     }
 
-    std.debug.print("\n[DEBUG] Initial values:", .{});
-    std.debug.print("\n  actual_starts: {any}", .{actual_starts});
-    std.debug.print("\n  actual_ends: {any}", .{actual_ends});
-    std.debug.print("\n  actual_steps: {any}", .{actual_steps});
+    std.log.debug("\n[DEBUG] Initial values:", .{});
+    std.log.debug("\n  actual_starts: {any}", .{actual_starts});
+    std.log.debug("\n  actual_ends: {any}", .{actual_ends});
+    std.log.debug("\n  actual_steps: {any}", .{actual_steps});
 
     // Update with provided values
     for (starts, 0..) |start, i| {
@@ -182,17 +182,17 @@ pub fn get_slice_output_shape(input_shape: []const usize, starts: []const i64, e
             actual_steps[axis_usize] = s[i];
         }
 
-        std.debug.print("\n[DEBUG] After processing axis {d}:", .{axis});
-        std.debug.print("\n  dim_size: {d}", .{dim_size});
-        std.debug.print("\n  actual_start: {d}", .{actual_start});
-        std.debug.print("\n  actual_end: {d}", .{actual_end});
-        std.debug.print("\n  actual_step: {d}", .{actual_steps[axis_usize]});
+        std.log.debug("\n[DEBUG] After processing axis {d}:", .{axis});
+        std.log.debug("\n  dim_size: {d}", .{dim_size});
+        std.log.debug("\n  actual_start: {d}", .{actual_start});
+        std.log.debug("\n  actual_end: {d}", .{actual_end});
+        std.log.debug("\n  actual_step: {d}", .{actual_steps[axis_usize]});
     }
 
-    std.debug.print("\n[DEBUG] Final values before shape calculation:", .{});
-    std.debug.print("\n  actual_starts: {any}", .{actual_starts});
-    std.debug.print("\n  actual_ends: {any}", .{actual_ends});
-    std.debug.print("\n  actual_steps: {any}", .{actual_steps});
+    std.log.debug("\n[DEBUG] Final values before shape calculation:", .{});
+    std.log.debug("\n  actual_starts: {any}", .{actual_starts});
+    std.log.debug("\n  actual_ends: {any}", .{actual_ends});
+    std.log.debug("\n  actual_steps: {any}", .{actual_steps});
 
     // Calculate output shape
     var output_shape = try pkg_allocator.alloc(usize, input_shape.len);
@@ -207,24 +207,24 @@ pub fn get_slice_output_shape(input_shape: []const usize, starts: []const i64, e
         if (step > 0) {
             if (end > start) {
                 dim_size = @intCast(@divTrunc((@as(i64, @intCast(end - start)) + step - 1), step));
-                std.debug.print("\n[DEBUG] Positive step calculation for dim {d}:", .{i});
-                std.debug.print("\n  end ({d}) - start ({d}) = {d}", .{ end, start, end - start });
-                std.debug.print("\n  (end-start) + step({d}) - 1 = {d}", .{ step, (end - start) + step - 1 });
-                std.debug.print("\n  final dim_size = {d}", .{dim_size});
+                std.log.debug("\n[DEBUG] Positive step calculation for dim {d}:", .{i});
+                std.log.debug("\n  end ({d}) - start ({d}) = {d}", .{ end, start, end - start });
+                std.log.debug("\n  (end-start) + step({d}) - 1 = {d}", .{ step, (end - start) + step - 1 });
+                std.log.debug("\n  final dim_size = {d}", .{dim_size});
             }
         } else {
             if (start > end) {
                 // For negative steps, treat end as inclusive.
                 const range = start - end;
                 dim_size = @intCast((@divTrunc(range, -step)) + 1);
-                std.debug.print("\n[DEBUG] Negative step calculation for dim {d}:", .{i});
-                std.debug.print("\n  start ({d}) - end ({d}) = range ({d})", .{ start, end, range });
-                std.debug.print("\n  (range) / abs(step) + 1 = {d}", .{dim_size});
+                std.log.debug("\n[DEBUG] Negative step calculation for dim {d}:", .{i});
+                std.log.debug("\n  start ({d}) - end ({d}) = range ({d})", .{ start, end, range });
+                std.log.debug("\n  (range) / abs(step) + 1 = {d}", .{dim_size});
             }
         }
         output_shape[i] = dim_size;
     }
 
-    std.debug.print("\n[DEBUG] Final output_shape: {any}\n", .{output_shape});
+    std.log.debug("\n[DEBUG] Final output_shape: {any}\n", .{output_shape});
     return output_shape;
 }

--- a/src/Core/Tensor/TensorMath/lib_shape_math/op_transpose.zig
+++ b/src/Core/Tensor/TensorMath/lib_shape_math/op_transpose.zig
@@ -97,13 +97,13 @@ fn transpose(comptime T: type, t: *Tensor(T), perms: []usize) !Tensor(T) {
 
 /// Given a 4D tensor it returns the tensor with the last 2 dimensions transposed. Operates on both data and shape, does not modify self, used by gemm.
 pub fn transposeLastTwo(comptime T: anytype, tensor: *const Tensor(T)) !Tensor(T) {
-    //std.debug.print("\n[DEBUG] transposeLastTwo:", .{});
-    //std.debug.print("\n  Input tensor shape: ", .{});
-    //for (tensor.shape) |s| std.debug.print("{d} ", .{s});
+    //std.log.debug("\n[DEBUG] transposeLastTwo:", .{});
+    //std.log.debug("\n  Input tensor shape: ", .{});
+    //for (tensor.shape) |s| std.log.debug("{d} ", .{s});
 
     // Verifying correct shape
     if (tensor.shape.len != 2 and tensor.shape.len != 4) {
-        //std.debug.print("\n  Error: Expected 2D or 4D tensor, got {d}D", .{tensor.shape.len});
+        //std.log.debug("\n  Error: Expected 2D or 4D tensor, got {d}D", .{tensor.shape.len});
         return TensorMathError.InputTensorsWrongShape;
     }
 
@@ -134,15 +134,15 @@ pub fn transposeLastTwo(comptime T: anytype, tensor: *const Tensor(T)) !Tensor(T
         newShape[3] = rows;
     }
 
-    //std.debug.print("\n  Rows: {d}, Cols: {d}, Total: {d}", .{ rows, cols, total });
-    //std.debug.print("\n  New shape: ", .{});
-    //for (newShape) |s| std.debug.print("{d} ", .{s});
+    //std.log.debug("\n  Rows: {d}, Cols: {d}, Total: {d}", .{ rows, cols, total });
+    //std.log.debug("\n  New shape: ", .{});
+    //for (newShape) |s| std.log.debug("{d} ", .{s});
 
     // Create a non-const copy of the input data using pkg_allocator
     const outData = try pkg_allocator.alloc(T, total);
     errdefer pkg_allocator.free(outData);
 
-    //std.debug.print("\n  Transposing data...", .{});
+    //std.log.debug("\n  Transposing data...", .{});
 
     if (tensor.shape.len == 2) {
         // Simple 2D transpose - Fixed indexing
@@ -168,7 +168,7 @@ pub fn transposeLastTwo(comptime T: anytype, tensor: *const Tensor(T)) !Tensor(T
         }
     }
 
-    //std.debug.print("\n  Transpose complete", .{});
+    //std.log.debug("\n  Transpose complete", .{});
 
     return Tensor(T){
         .data = outData,
@@ -228,11 +228,11 @@ pub fn transpose_onnx_lean(
     if (perm) |p| {
         // Validate length
         if (p.len != perm_rank) {
-            //std.debug.print("ERROR: transpose_onnx_lean perm.len = {}, perm_rank = {}. Should be equal.\\n", .{ p.len, perm_rank });
+            //std.log.debug("ERROR: transpose_onnx_lean perm.len = {}, perm_rank = {}. Should be equal.\\n", .{ p.len, perm_rank });
             return error.InvalidPermutation;
         }
         if (input_rank > perm_rank) {
-            //std.debug.print("ERROR: transpose_onnx_lean input_rank ({}) > perm_rank ({}) not supported\\n", .{ input_rank, perm_rank });
+            //std.log.debug("ERROR: transpose_onnx_lean input_rank ({}) > perm_rank ({}) not supported\\n", .{ input_rank, perm_rank });
             return error.UnsupportedBroadcast;
         }
 
@@ -432,7 +432,7 @@ pub fn get_transpose_output_shape(input_shape: []const usize, perm: ?[]const usi
     if (perm) |p| {
         if (p.len != perm_rank) {
             // This case should technically not happen if perm_rank is derived from p.len, but good practice
-            std.debug.print("ERROR: perm length mismatch internal logic! p.len={} perm_rank={}\\n", .{ p.len, perm_rank });
+            std.log.warn("ERROR: perm length mismatch internal logic! p.len={} perm_rank={}\\n", .{ p.len, perm_rank });
             return error.InvalidPermutation;
         }
 
@@ -472,7 +472,7 @@ pub fn get_transpose_output_shape(input_shape: []const usize, perm: ?[]const usi
     for (0..perm_rank) |i| {
         const input_dim_index = real_perm[i];
         if (input_dim_index >= perm_rank) { // Sanity check
-            std.debug.print("ERROR: real_perm[{}]={} is out of bounds for perm_rank={}\\n", .{ i, input_dim_index, perm_rank });
+            std.log.warn("ERROR: real_perm[{}]={} is out of bounds for perm_rank={}\\n", .{ i, input_dim_index, perm_rank });
             return error.InvalidPermutation;
         }
         output_shape[i] = effective_input_shape[input_dim_index];

--- a/src/Core/Tensor/TensorMath/op_batchNormalization.zig
+++ b/src/Core/Tensor/TensorMath/op_batchNormalization.zig
@@ -47,7 +47,7 @@ pub inline fn batchNormalization_lean(
 ) !void {
     _ = momentum; //reduntant, used only for training
     if (training_mode) {
-        std.debug.print("\n\nERROR: training_mode not available for batchNormalization!! \n", .{});
+        std.log.warn("\n\nERROR: training_mode not available for batchNormalization!! \n", .{});
         return error.training_mode_NotAvailable;
     }
 
@@ -57,11 +57,11 @@ pub inline fn batchNormalization_lean(
     // Assume Channel dimension is axis 1 (common for NCHW)
     const C = input.shape[1];
     if (C != scales.size or C != B.size or C != input_mean.size or C != input_var.size) {
-        std.debug.print("ERROR: Channel size mismatch. Input C={}, Scale={}, B={}, Mean={}, Var={}\n", .{ C, scales.size, B.size, input_mean.size, input_var.size });
+        std.log.warn("ERROR: Channel size mismatch. Input C={}, Scale={}, B={}, Mean={}, Var={}\n", .{ C, scales.size, B.size, input_mean.size, input_var.size });
         return error.ChannelSizeMismatch;
     }
     if (output.shape.len != dims or !std.mem.eql(usize, output.shape, input.shape)) {
-        std.debug.print("ERROR: Output shape mismatch. Input={any}, Output={any}\n", .{ input.shape, output.shape });
+        std.log.warn("ERROR: Output shape mismatch. Input={any}, Output={any}\n", .{ input.shape, output.shape });
         return error.ShapeMismatch; // Ensure output shape matches input shape
     }
 

--- a/src/Core/Tensor/TensorMath/op_convolution.zig
+++ b/src/Core/Tensor/TensorMath/op_convolution.zig
@@ -42,10 +42,10 @@ pub export fn setLogFunctionC(func: ?*const fn ([*c]u8) callconv(.C) void) void 
     log_functionC = func;
 }
 pub fn OnnxConvLean(comptime T: type, input: *Tensor(T), kernel: *Tensor(T), output: *Tensor(T), bias: ?*const Tensor(T), stride: []const usize, pads: ?[]const usize, dilations: ?[]const usize, group: ?usize, auto_pad: ?[]const u8) !void {
-    // std.debug.print("\n[DEBUG] OnnxConvLean - Input shape: {any}", .{input.shape});
-    // std.debug.print("\n[DEBUG] OnnxConvLean - Kernel shape: {any}", .{kernel.shape});
-    // std.debug.print("\n[DEBUG] OnnxConvLean - Output shape: {any}", .{output.shape});
-    // std.debug.print("\n[DEBUG] OnnxConvLean - Stride: {any}", .{stride});
+    // std.log.debug("\n[DEBUG] OnnxConvLean - Input shape: {any}", .{input.shape});
+    // std.log.debug("\n[DEBUG] OnnxConvLean - Kernel shape: {any}", .{kernel.shape});
+    // std.log.debug("\n[DEBUG] OnnxConvLean - Output shape: {any}", .{output.shape});
+    // std.log.debug("\n[DEBUG] OnnxConvLean - Stride: {any}", .{stride});
 
     // Input validation: Ensure 4D tensors for input (N,C,H,W) and kernel (M,C/g,kH,kW)
 
@@ -132,8 +132,8 @@ pub fn OnnxConvLean(comptime T: type, input: *Tensor(T), kernel: *Tensor(T), out
     const dilation_h = if (dilations) |d| if (d.len > 0) d[0] else 1 else 1;
     const dilation_w = if (dilations) |d| if (d.len > 1) d[1] else d[0] else 1;
 
-    // std.debug.print("\n[DEBUG] Computed strides: h={}, w={}", .{ stride_h, stride_w });
-    // std.debug.print("\n[DEBUG] Computed dilations: h={}, w={}", .{ dilation_h, dilation_w });
+    // std.log.debug("\n[DEBUG] Computed strides: h={}, w={}", .{ stride_h, stride_w });
+    // std.log.debug("\n[DEBUG] Computed dilations: h={}, w={}", .{ dilation_h, dilation_w });
 
     // Calculate dilated kernel dimensions
     const dilated_kernel_h = (kernel_height - 1) * dilation_h + 1;
@@ -149,7 +149,7 @@ pub fn OnnxConvLean(comptime T: type, input: *Tensor(T), kernel: *Tensor(T), out
     }
     // Handle padding: Either auto_pad or explicit pads
     if (auto_pad) |pad_mode| {
-        //std.debug.print("\n[DEBUG] pad_mode: {s}", .{pad_mode});
+        //std.log.debug("\n[DEBUG] pad_mode: {s}", .{pad_mode});
         if (std.mem.eql(u8, pad_mode, "VALID")) {
             // No padding
         } else if (std.mem.eql(u8, pad_mode, "SAME_UPPER") or std.mem.eql(u8, pad_mode, "SAME_LOWER")) {
@@ -289,8 +289,8 @@ pub fn OnnxConvLean(comptime T: type, input: *Tensor(T), kernel: *Tensor(T), out
     }
 
     //print  result e output shape
-    //std.debug.print("\n[DEBUG] Result shape: {any}", .{result.shape});
-    //std.debug.print("\n[DEBUG] Output shape: {any}", .{output.shape});
+    //std.log.debug("\n[DEBUG] Result shape: {any}", .{result.shape});
+    //std.log.debug("\n[DEBUG] Output shape: {any}", .{output.shape});
 
     // Validate output dimensions and copy result
     // Output shape should match the expected 4D shape based on actual_input_shape
@@ -305,7 +305,7 @@ pub fn OnnxConvLean(comptime T: type, input: *Tensor(T), kernel: *Tensor(T), out
     } // else: Let the data length check catch other invalid output shapes
 
     if (!shape_match) {
-        //std.debug.print("\n[DEBUG] OnnxConvLean: Result shape: {any}", .{result.shape});
+        //std.log.debug("\n[DEBUG] OnnxConvLean: Result shape: {any}", .{result.shape});
         // Adjust error message or logic if needed, considering the 3D input case
         if (log_functionC) |log_func| {
             var buf: [256]u8 = undefined;
@@ -455,7 +455,7 @@ pub fn convolve_tensor_with_bias(
     };
     errdefer output.deinit();
 
-    //std.debug.print("\n[DEBUG] Output shape: {any}", .{output.shape});
+    //std.log.debug("\n[DEBUG] Output shape: {any}", .{output.shape});
 
     const kernel_size = [2]usize{ kernel_height, kernel_width };
     const stride_size = [2]usize{ stride[0], stride[1] };
@@ -901,13 +901,13 @@ pub fn convolve_tensor_with_bias_memory_efficient(
 }
 
 pub fn get_convolution_output_shape(input_shape: []const usize, kernel_shape: []const usize, stride: []const usize, pads: ?[]const usize, dilations: ?[]const usize, auto_pad: ?[]const u8) ![4]usize {
-    std.debug.print("\n =================================================", .{});
-    std.debug.print("\n[DEBUG] get_convolution_output_shape - input_shape: {any}", .{input_shape});
-    std.debug.print("\n[DEBUG] get_convolution_output_shape - kernel_shape: {any}", .{kernel_shape});
-    std.debug.print("\n[DEBUG] get_convolution_output_shape - stride: {any}", .{stride});
-    std.debug.print("\n[DEBUG] get_convolution_output_shape - pads: {any}", .{pads});
-    std.debug.print("\n[DEBUG] get_convolution_output_shape - dilations: {any}", .{dilations});
-    std.debug.print("\n[DEBUG] get_convolution_output_shape - auto_pad: {any}", .{auto_pad});
+    //std.log.debug("\n =================================================", .{});
+    // std.log.debug("\n[DEBUG] get_convolution_output_shape - input_shape: {any}", .{input_shape});
+    // std.log.debug("\n[DEBUG] get_convolution_output_shape - kernel_shape: {any}", .{kernel_shape});
+    // std.log.debug("\n[DEBUG] get_convolution_output_shape - stride: {any}", .{stride});
+    // std.log.debug("\n[DEBUG] get_convolution_output_shape - pads: {any}", .{pads});
+    // std.log.debug("\n[DEBUG] get_convolution_output_shape - dilations: {any}", .{dilations});
+    // std.log.debug("\n[DEBUG] get_convolution_output_shape - auto_pad: {any}", .{auto_pad});
 
     // --- Handle 3D input shape by assuming batch size = 1 ---
     var actual_input_shape: [4]usize = undefined;
@@ -917,17 +917,17 @@ pub fn get_convolution_output_shape(input_shape: []const usize, kernel_shape: []
         actual_input_shape[1] = input_shape[0]; // Channels
         actual_input_shape[2] = input_shape[1]; // Height
         actual_input_shape[3] = input_shape[2]; // Width
-        std.debug.print("\n[DEBUG] get_convolution_output_shape - Adjusted 3D input shape to 4D: {any}", .{actual_input_shape});
+        std.log.debug("\n[DEBUG] get_convolution_output_shape - Adjusted 3D input shape to 4D: {any}", .{actual_input_shape});
     } else if (input_shape.len == 4) {
         @memcpy(&actual_input_shape, input_shape[0..4]);
     } else {
-        std.debug.print("\n[ERROR] get_convolution_output_shape - Invalid input dimensions: {}", .{input_shape.len});
+        std.log.warn("\n[ERROR] get_convolution_output_shape - Invalid input dimensions: {}", .{input_shape.len});
         return TensorMathError.InvalidDimensions;
     }
     // --- End Shape Adjustment ---
 
     if (kernel_shape.len != 4) {
-        std.debug.print("\n[ERROR] get_convolution_output_shape - Invalid kernel dimensions: {}", .{kernel_shape.len});
+        std.log.warn("\n[ERROR] get_convolution_output_shape - Invalid kernel dimensions: {}", .{kernel_shape.len});
         return TensorMathError.InvalidDimensions;
     }
 
@@ -1020,7 +1020,7 @@ pub fn get_convolution_output_shape(input_shape: []const usize, kernel_shape: []
     }
 
     if (expected_out_height <= 0 or expected_out_width <= 0) {
-        std.debug.print("\n[ERROR] get_convolution_output_shape - Calculated output dimensions are non-positive: H={}, W={}", .{ expected_out_height, expected_out_width });
+        std.log.warn("\n[ERROR] get_convolution_output_shape - Calculated output dimensions are non-positive: H={}, W={}", .{ expected_out_height, expected_out_width });
         return TensorMathError.InvalidDimensions;
     }
 
@@ -1033,11 +1033,11 @@ pub fn get_convolution_output_shape(input_shape: []const usize, kernel_shape: []
 // --------------------------------------------------
 // --------- standard im2col
 pub fn im2col(comptime T: type, input: *Tensor(T), kernel: [2]usize, stride: [2]usize, dilations: ?[]const usize, group: usize) !Tensor(T) {
-    // std.debug.print("\n[DEBUG] im2col - Starting transformation", .{});
-    // std.debug.print("\n[DEBUG] Input shape: {any}", .{input.shape});
-    // std.debug.print("\n[DEBUG] Kernel size: {any}", .{kernel});
-    // std.debug.print("\n[DEBUG] Stride: {any}", .{stride});
-    // std.debug.print("\n[DEBUG] Group: {}", .{group});
+    // std.log.debug("\n[DEBUG] im2col - Starting transformation", .{});
+    // std.log.debug("\n[DEBUG] Input shape: {any}", .{input.shape});
+    // std.log.debug("\n[DEBUG] Kernel size: {any}", .{kernel});
+    // std.log.debug("\n[DEBUG] Stride: {any}", .{stride});
+    // std.log.debug("\n[DEBUG] Group: {}", .{group});
 
     if (input.shape.len != 4) {
         return TensorMathError.InputTensorsWrongShape;
@@ -1087,7 +1087,7 @@ pub fn im2col(comptime T: type, input: *Tensor(T), kernel: [2]usize, stride: [2]
     const cols_per_group = channels_per_group * kernel_h * kernel_w;
     const cols = cols_per_group * group; // Total columns across all groups
 
-    //std.debug.print("\n[DEBUG] im2col output shape - rows: {}, cols: {}", .{ rows, cols });
+    //std.log.debug("\n[DEBUG] im2col output shape - rows: {}, cols: {}", .{ rows, cols });
 
     var col_shape = [_]usize{ rows, cols };
     var col_matrix = Tensor(T).fromShape(&pkg_allocator, &col_shape) catch {
@@ -1105,9 +1105,9 @@ pub fn im2col(comptime T: type, input: *Tensor(T), kernel: [2]usize, stride: [2]
 }
 
 pub inline fn lean_im2col(comptime T: type, input: *Tensor(T), kernel: [2]usize, stride: [2]usize, dilations: ?[]const usize, group: usize, output: *Tensor(T)) !void {
-    // std.debug.print("\n[DEBUG] lean_im2col - Starting transformation", .{});
-    // std.debug.print("\n[DEBUG] Input shape: {any}, Output shape: {any}", .{ input.shape, output.shape });
-    // std.debug.print("\n[DEBUG] lean_im2col - Group: {}", .{group});
+    // std.log.debug("\n[DEBUG] lean_im2col - Starting transformation", .{});
+    // std.log.debug("\n[DEBUG] Input shape: {any}, Output shape: {any}", .{ input.shape, output.shape });
+    // std.log.debug("\n[DEBUG] lean_im2col - Group: {}", .{group});
 
     const batch_size = input.shape[0];
     const channels = input.shape[1];
@@ -1258,9 +1258,9 @@ pub inline fn lean_im2col(comptime T: type, input: *Tensor(T), kernel: [2]usize,
 /// Input shape: [batch_size * out_height * out_width, channels * kernel_height * kernel_width]
 /// Output shape: [batch_size, channels, height, width]
 pub fn col2im(comptime T: type, col_matrix: *Tensor(T), output_shape: []const usize, kernel: [2]usize, stride: [2]usize) !Tensor(T) {
-    // std.debug.print("\n[DEBUG] col2im - Starting transformation", .{});
-    // std.debug.print("\n[DEBUG] Col matrix shape: {any}", .{col_matrix.shape});
-    // std.debug.print("\n[DEBUG] Target output shape: {any}", .{output_shape});
+    // std.log.debug("\n[DEBUG] col2im - Starting transformation", .{});
+    // std.log.debug("\n[DEBUG] Col matrix shape: {any}", .{col_matrix.shape});
+    // std.log.debug("\n[DEBUG] Target output shape: {any}", .{output_shape});
 
     if (output_shape.len != 4) {
         return TensorMathError.InvalidDimensions;
@@ -1493,13 +1493,13 @@ pub fn OnnxConv(comptime T: type, input: *Tensor(T), kernel: *Tensor(T), bias: ?
 }
 
 pub fn debug_print_max_pool(input_shape: []const usize, kernel_shape: []const usize, stride: []const usize, padding: ?[]const usize) void {
-    std.debug.print("\n[DEBUG] MaxPool - Input shape: {any}", .{input_shape});
-    std.debug.print("\n[DEBUG] MaxPool - Kernel shape: {any}", .{kernel_shape});
-    std.debug.print("\n[DEBUG] MaxPool - Stride: {any}", .{stride});
+    std.log.debug("\n[DEBUG] MaxPool - Input shape: {any}", .{input_shape});
+    std.log.debug("\n[DEBUG] MaxPool - Kernel shape: {any}", .{kernel_shape});
+    std.log.debug("\n[DEBUG] MaxPool - Stride: {any}", .{stride});
     if (padding) |p| {
-        std.debug.print("\n[DEBUG] MaxPool - Padding: {any}", .{p});
+        std.log.debug("\n[DEBUG] MaxPool - Padding: {any}", .{p});
     } else {
-        std.debug.print("\n[DEBUG] MaxPool - Padding: null", .{});
+        std.log.debug("\n[DEBUG] MaxPool - Padding: null", .{});
     }
 
     // Calculate dilated kernel dimensions (MaxPool typically has no dilation, but for consistency)
@@ -1509,11 +1509,11 @@ pub fn debug_print_max_pool(input_shape: []const usize, kernel_shape: []const us
     const in_height = if (input_shape.len > 2) input_shape[2] else 1;
     const in_width = if (input_shape.len > 3) input_shape[3] else 1;
 
-    std.debug.print("\n[DEBUG] MaxPool - in_height: {}, in_width: {}, kernel_h: {}, kernel_w: {}", .{ in_height, in_width, kernel_h, kernel_w });
+    std.log.debug("\n[DEBUG] MaxPool - in_height: {}, in_width: {}, kernel_h: {}, kernel_w: {}", .{ in_height, in_width, kernel_h, kernel_w });
 
     // Check if this is a problematic case (kernel larger than input)
     if (in_height < kernel_h or in_width < kernel_w) {
-        std.debug.print("\n[DEBUG] MaxPool - WARNING: Kernel is larger than input dimensions!", .{});
+        std.log.debug("\n[DEBUG] MaxPool - WARNING: Kernel is larger than input dimensions!", .{});
     }
 }
 
@@ -1523,7 +1523,7 @@ pub fn get_max_pool_output_shape(input_shape: []const usize, kernel_shape: []con
     _ = padding;
     // Special case handling for MaxPool when kernel is larger than input
     if (input_shape.len > 2 and input_shape[2] < kernel_shape[0]) {
-        // std.debug.print("\n[DEBUG] MaxPool - Using special case for small input", .{});
+        // std.log.debug("\n[DEBUG] MaxPool - Using special case for small input", .{});
 
         // Return a shape with 1x1 spatial dimensions
         var result = try pkg_allocator.alloc(usize, 4);

--- a/src/Core/Tensor/TensorMath/op_gemm.zig
+++ b/src/Core/Tensor/TensorMath/op_gemm.zig
@@ -73,12 +73,12 @@ pub fn gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(T), a
 
     // debug
     // for (0..A.data.len) |i|
-    //     std.debug.print("\n gemm A[{d}] {d}", .{ i, A.data[i] });
+    //     std.log.debug("\n gemm A[{d}] {d}", .{ i, A.data[i] });
     // for (0..B.data.len) |i|
-    //     std.debug.print("\n gemm B[{d}] {d}", .{ i, B.data[i] });
+    //     std.log.debug("\n gemm B[{d}] {d}", .{ i, B.data[i] });
     // if (C) |CC| {
     //     for (0..CC.data.len) |i|
-    //         std.debug.print("\n gemm C[{d}] {d}", .{ i, CC.data[i] });
+    //         std.log.debug("\n gemm C[{d}] {d}", .{ i, CC.data[i] });
     // }
 
     try lean_gemm(T, A, B, C, alpha, beta, transA, transB, &result);
@@ -89,18 +89,18 @@ pub fn gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(T), a
 /// Lean version of gemm, output Tensor must be preconstructed and 0 filled
 /// NOTE: (IMPORTANT FOR CODE GEN) Since multibatch/multichannel is not supported by mat_mul neither gemm does. Remove this note and edit "discrepancies from the standard onnx" if this is changed in the future.
 pub fn lean_gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(T), alpha: T, beta: T, transA: bool, transB: bool, result: *Tensor(T)) !void {
-    //std.debug.print("\n[DEBUG] lean_gemm:", .{});
-    //std.debug.print("\n  A shape: ", .{});
-    //for (A.shape) |s| std.debug.print("{d} ", .{s});
+    //std.log.debug("\n[DEBUG] lean_gemm:", .{});
+    //std.log.debug("\n  A shape: ", .{});
+    //for (A.shape) |s| std.log.debug("{d} ", .{s});
 
-    //std.debug.print("\n  B shape: ", .{});
-    //for (B.shape) |s| std.debug.print("{d} ", .{s});
+    //std.log.debug("\n  B shape: ", .{});
+    //for (B.shape) |s| std.log.debug("{d} ", .{s});
 
-    //std.debug.print("\n  Result shape: ", .{});
-    //for (result.shape) |s| std.debug.print("{d} ", .{s});
+    //std.log.debug("\n  Result shape: ", .{});
+    //for (result.shape) |s| std.log.debug("{d} ", .{s});
 
-    //std.debug.print("\n  Alpha: {d}, Beta: {d}", .{ alpha, beta });
-    //std.debug.print("\n  TransA: {}, TransB: {}", .{ transA, transB });
+    //std.log.debug("\n  Alpha: {d}, Beta: {d}", .{ alpha, beta });
+    //std.log.debug("\n  TransA: {}, TransB: {}", .{ transA, transB });
 
     var actual_A: Tensor(T) = undefined;
     var actual_B: Tensor(T) = undefined;
@@ -109,18 +109,18 @@ pub fn lean_gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(
 
     // applying transposition
     if (transA) {
-        //std.debug.print("\n  Transposing A...", .{});
+        //std.log.debug("\n  Transposing A...", .{});
         actual_A = try TensMath.transposeLastTwo(T, A);
         actual_A_ptr = &actual_A;
-        //std.debug.print("\n  A shape after transpose: ", .{});
-        //for (actual_A_ptr.shape) |s| std.debug.print("{d} ", .{s});
+        //std.log.debug("\n  A shape after transpose: ", .{});
+        //for (actual_A_ptr.shape) |s| std.log.debug("{d} ", .{s});
     }
     if (transB) {
-        //std.debug.print("\n  Transposing B...", .{});
+        //std.log.debug("\n  Transposing B...", .{});
         actual_B = try TensMath.transposeLastTwo(T, B);
         actual_B_ptr = &actual_B;
-        //std.debug.print("\n  B shape after transpose: ", .{});
-        //for (actual_B_ptr.shape) |s| std.debug.print("{d} ", .{s});
+        //std.log.debug("\n  B shape after transpose: ", .{});
+        //for (actual_B_ptr.shape) |s| std.log.debug("{d} ", .{s});
     }
     defer {
         if (transA) actual_A.deinit();
@@ -134,30 +134,30 @@ pub fn lean_gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(
         try op_mat_mul.lean_mat_mul(T, actual_A_ptr, actual_B_ptr, result);
     }
     // result = alpha * A * B
-    //std.debug.print("\n  Performing matrix multiplication...", .{});
+    //std.log.debug("\n  Performing matrix multiplication...", .{});
 
-    //std.debug.print("\n  Applying alpha scaling...", .{});
+    //std.log.debug("\n  Applying alpha scaling...", .{});
     for (0..result.size) |i| {
         result.data[i] *= alpha;
     }
 
     // result = result + beta * C
     if (C) |actual_C_ptr| {
-        //std.debug.print("\n  C shape: ", .{});
-        //for (actual_C_ptr.shape) |s| std.debug.print("{d} ", .{s});
+        //std.log.debug("\n  C shape: ", .{});
+        //for (actual_C_ptr.shape) |s| std.log.debug("{d} ", .{s});
 
         if (beta != 0) {
-            //std.debug.print("\n  Adding beta * C...", .{});
+            //std.log.debug("\n  Adding beta * C...", .{});
             // no broadcast necessary
             if (result.size == actual_C_ptr.size) {
-                //std.debug.print("\n  No broadcast needed", .{});
+                //std.log.debug("\n  No broadcast needed", .{});
                 for (0..result.size) |i| {
                     result.data[i] += actual_C_ptr.data[i] * beta;
                 }
             }
             // broadcast from C to result
             else {
-                //std.debug.print("\n  Broadcasting C...", .{});
+                //std.log.debug("\n  Broadcasting C...", .{});
                 const res_rows = result.shape[result.shape.len - 2];
                 const res_cols = result.shape[result.shape.len - 1];
 
@@ -165,7 +165,7 @@ pub fn lean_gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(
                 const c_rows = if (actual_C_ptr.shape.len >= 2) actual_C_ptr.shape[actual_C_ptr.shape.len - 2] else 1;
                 const c_cols = if (actual_C_ptr.shape.len >= 1) actual_C_ptr.shape[actual_C_ptr.shape.len - 1] else 1;
 
-                //std.debug.print("\n  res_rows: {d}, res_cols: {d}, c_rows: {d}, c_cols: {d}", .{ res_rows, res_cols, c_rows, c_cols });
+                //std.log.debug("\n  res_rows: {d}, res_cols: {d}, c_rows: {d}, c_cols: {d}", .{ res_rows, res_cols, c_rows, c_cols });
 
                 for (0..actual_A_ptr.shape[0]) |b| {
                     for (0..actual_A_ptr.shape[1]) |c| {
@@ -191,17 +191,17 @@ pub fn lean_gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(
     if (transA) actual_A.deinit();
     if (transB) actual_B.deinit();
 
-    //std.debug.print("\n[DEBUG] lean_gemm completed\n", .{});
+    //std.log.debug("\n[DEBUG] lean_gemm completed\n", .{});
 }
 
 pub fn transposeLastTwo(comptime T: anytype, tensor: *const Tensor(T)) !Tensor(T) {
-    std.debug.print("\n[DEBUG] transposeLastTwo:", .{});
-    std.debug.print("\n  Input tensor shape: ", .{});
-    for (tensor.shape) |s| std.debug.print("{d} ", .{s});
+    std.log.debug("\n[DEBUG] transposeLastTwo:", .{});
+    std.log.debug("\n  Input tensor shape: ", .{});
+    for (tensor.shape) |s| std.log.debug("{d} ", .{s});
 
     // Verifying correct shape
     if (tensor.shape.len != 2 and tensor.shape.len != 4) {
-        std.debug.print("\n  Error: Expected 2D or 4D tensor, got {d}D", .{tensor.shape.len});
+        std.log.debug("\n  Error: Expected 2D or 4D tensor, got {d}D", .{tensor.shape.len});
         return TensorMathError.InputTensorsWrongShape;
     }
 
@@ -232,15 +232,15 @@ pub fn transposeLastTwo(comptime T: anytype, tensor: *const Tensor(T)) !Tensor(T
         newShape[3] = rows;
     }
 
-    std.debug.print("\n  Rows: {d}, Cols: {d}, Total: {d}", .{ rows, cols, total });
-    std.debug.print("\n  New shape: ", .{});
-    for (newShape) |s| std.debug.print("{d} ", .{s});
+    std.log.debug("\n  Rows: {d}, Cols: {d}, Total: {d}", .{ rows, cols, total });
+    std.log.debug("\n  New shape: ", .{});
+    for (newShape) |s| std.log.debug("{d} ", .{s});
 
     // Create a non-const copy of the input data using pkg_allocator
     const outData = try pkg_allocator.alloc(T, total);
     errdefer pkg_allocator.free(outData);
 
-    std.debug.print("\n  Transposing data...", .{});
+    std.log.debug("\n  Transposing data...", .{});
 
     if (tensor.shape.len == 2) {
         // Simple 2D transpose - Fixed indexing
@@ -266,7 +266,7 @@ pub fn transposeLastTwo(comptime T: anytype, tensor: *const Tensor(T)) !Tensor(T
         }
     }
 
-    std.debug.print("\n  Transpose complete", .{});
+    std.log.debug("\n  Transpose complete", .{});
 
     return Tensor(T){
         .data = outData,

--- a/src/Core/Tensor/TensorMath/op_pooling.zig
+++ b/src/Core/Tensor/TensorMath/op_pooling.zig
@@ -19,26 +19,26 @@ pub const AutoPadType = enum {
 };
 
 pub fn get_pooling_output_shape(input_shape: []const usize, kernel: [2]usize, stride: [2]usize) ![4]usize {
-    // std.debug.print("\n[DEBUG] get_pooling_output_shape - Input shape: {any}", .{input_shape});
-    // std.debug.print("\n[DEBUG] get_pooling_output_shape - Kernel: {any}", .{kernel});
-    // std.debug.print("\n[DEBUG] get_pooling_output_shape - Stride: {any}", .{stride});
+    // std.log.debug("\n[DEBUG] get_pooling_output_shape - Input shape: {any}", .{input_shape});
+    // std.log.debug("\n[DEBUG] get_pooling_output_shape - Kernel: {any}", .{kernel});
+    // std.log.debug("\n[DEBUG] get_pooling_output_shape - Stride: {any}", .{stride});
 
     if (input_shape.len != 4) {
-        std.debug.print("\n[DEBUG] ERROR: Invalid dimensions - input shape length is not 4", .{});
+        std.log.warn("\n[DEBUG] ERROR: Invalid dimensions - input shape length is not 4", .{});
         return TensorMathError.InvalidDimensions;
     }
 
     if (kernel[0] == 0 or kernel[1] == 0 or stride[0] == 0 or stride[1] == 0) {
-        std.debug.print("\n[DEBUG] ERROR: Wrong stride - kernel or stride contains zeros", .{});
+        std.log.warn("\n[DEBUG] ERROR: Wrong stride - kernel or stride contains zeros", .{});
         return TensorMathError.WrongStride;
     }
 
     if (kernel[0] > input_shape[2] or kernel[1] > input_shape[3]) {
-        std.debug.print("\n[DEBUG] WARNING: Kernel size ({},{}) > input dimensions ({},{})", .{ kernel[0], kernel[1], input_shape[2], input_shape[3] });
+        std.log.warn("\n[DEBUG] WARNING: Kernel size ({},{}) > input dimensions ({},{})", .{ kernel[0], kernel[1], input_shape[2], input_shape[3] });
 
         // SPECIAL CASE: Instead of error, return a shape with 1x1 spatial dimensions
         // when kernel is larger than input
-        std.debug.print("\n[DEBUG] Using special case: returning output with 1x1 spatial dimensions", .{});
+        std.log.debug("\n[DEBUG] Using special case: returning output with 1x1 spatial dimensions", .{});
         const batch_size = input_shape[0];
         const channels = input_shape[1];
 
@@ -50,7 +50,7 @@ pub fn get_pooling_output_shape(input_shape: []const usize, kernel: [2]usize, st
     const out_height = (input_shape[2] - kernel[0]) / stride[0] + 1;
     const out_width = (input_shape[3] - kernel[1]) / stride[1] + 1;
 
-    // std.debug.print("\n[DEBUG] Calculated output dimensions - height: {}, width: {}", .{ out_height, out_width });
+    // std.log.debug("\n[DEBUG] Calculated output dimensions - height: {}, width: {}", .{ out_height, out_width });
     return [4]usize{ batch_size, channels, out_height, out_width };
 }
 
@@ -503,16 +503,16 @@ pub fn get_onnx_maxpool_output_shape(
     auto_pad: AutoPadType,
     ceil_mode: bool,
 ) ![]usize {
-    // std.debug.print("\n[DEBUG] get_onnx_maxpool_output_shape - Input shape: {any}", .{input_shape});
-    // std.debug.print("\n[DEBUG] get_onnx_maxpool_output_shape - Kernel shape: {any}", .{kernel_shape});
-    // std.debug.print("\n[DEBUG] get_onnx_maxpool_output_shape - Strides: {any}", .{strides});
-    // std.debug.print("\n[DEBUG] get_onnx_maxpool_output_shape - Dilations: {any}", .{dilations});
-    // std.debug.print("\n[DEBUG] get_onnx_maxpool_output_shape - Pads: {any}", .{pads});
-    // std.debug.print("\n[DEBUG] get_onnx_maxpool_output_shape - AutoPad: {}", .{auto_pad});
-    // std.debug.print("\n[DEBUG] get_onnx_maxpool_output_shape - Ceil mode: {}", .{ceil_mode});
+    // std.log.debug("\n[DEBUG] get_onnx_maxpool_output_shape - Input shape: {any}", .{input_shape});
+    // std.log.debug("\n[DEBUG] get_onnx_maxpool_output_shape - Kernel shape: {any}", .{kernel_shape});
+    // std.log.debug("\n[DEBUG] get_onnx_maxpool_output_shape - Strides: {any}", .{strides});
+    // std.log.debug("\n[DEBUG] get_onnx_maxpool_output_shape - Dilations: {any}", .{dilations});
+    // std.log.debug("\n[DEBUG] get_onnx_maxpool_output_shape - Pads: {any}", .{pads});
+    // std.log.debug("\n[DEBUG] get_onnx_maxpool_output_shape - AutoPad: {}", .{auto_pad});
+    // std.log.debug("\n[DEBUG] get_onnx_maxpool_output_shape - Ceil mode: {}", .{ceil_mode});
 
     if (input_shape.len != 4) {
-        std.debug.print("\n[DEBUG] ERROR: Invalid dimensions - input shape length is not 4", .{});
+        std.log.warn("\n[DEBUG] ERROR: Invalid dimensions - input shape length is not 4", .{});
         return TensorMathError.InvalidDimensions;
     }
 
@@ -523,8 +523,8 @@ pub fn get_onnx_maxpool_output_shape(
 
     // Handle special case: kernel larger than input
     if (kernel_shape[0] > input_height or kernel_shape[1] > input_width) {
-        std.debug.print("\n[DEBUG] WARNING: Kernel size ({},{}) > input dimensions ({},{})", .{ kernel_shape[0], kernel_shape[1], input_height, input_width });
-        std.debug.print("\n[DEBUG] Using special case: returning output with 1x1 spatial dimensions", .{});
+        std.log.warn("\n[DEBUG] WARNING: Kernel size ({},{}) > input dimensions ({},{})", .{ kernel_shape[0], kernel_shape[1], input_height, input_width });
+        std.log.debug("\n[DEBUG] Using special case: returning output with 1x1 spatial dimensions", .{});
 
         var output_shape = try pkg_allocator.alloc(usize, 4);
         output_shape[0] = batch_size;
@@ -834,7 +834,7 @@ pub fn lean_onnx_averagepool(
                         }
                     }
                     if (count == 0) {
-                        std.debug.print("Warning: count == 0 at oh={}, ow={}, ih_start={}, iw_start={}, pad_top={}, pad_left={}\n", .{ oh, ow, ih_start, iw_start, pad_top, pad_left });
+                        std.log.warn("Warning: count == 0 at oh={}, ow={}, ih_start={}, iw_start={}, pad_top={}, pad_left={}\n", .{ oh, ow, ih_start, iw_start, pad_top, pad_left });
                     }
                     // Store result
                     output.data[output_offset + oh * out_width + ow] = if (count > 0) sum / @as(T, @floatFromInt(count)) else 0;

--- a/src/Core/Tensor/tensor.zig
+++ b/src/Core/Tensor/tensor.zig
@@ -386,7 +386,7 @@ pub fn Tensor(comptime T: type) type {
 
                 // Use result to prevent optimization
                 if (result == 0) {
-                    std.debug.print("Benchmark result: {}\n", .{result});
+                    std.log.info("Benchmark result: {}\n", .{result});
                 }
             }
 
@@ -404,7 +404,7 @@ pub fn Tensor(comptime T: type) type {
 
                 // Use result to prevent optimization
                 if (result == 0) {
-                    std.debug.print("Benchmark result: {}\n", .{result});
+                    std.log.info("Benchmark result: {}\n", .{result});
                 }
             }
 
@@ -543,24 +543,24 @@ pub fn Tensor(comptime T: type) type {
         /// Prints all the possible details of a tensor.
         /// Very usefull in debugging.
         pub fn info(self: *@This()) void {
-            std.debug.print("\ntensor infos: ", .{});
-            std.debug.print("\n  data type:{}", .{@TypeOf(self.data[0])});
-            std.debug.print("\n  size:{}", .{self.size});
-            std.debug.print("\n shape.len:{} shape: [ ", .{self.shape.len});
+            std.log.debug("\ntensor infos: ", .{});
+            std.log.debug("\n  data type:{}", .{@TypeOf(self.data[0])});
+            std.log.debug("\n  size:{}", .{self.size});
+            std.log.debug("\n shape.len:{} shape: [ ", .{self.shape.len});
             for (0..self.shape.len) |i| {
-                std.debug.print("{} ", .{self.shape[i]});
+                std.log.debug("{} ", .{self.shape[i]});
             }
-            std.debug.print("] ", .{});
+            std.log.debug("] ", .{});
             //self.print();
         }
 
         /// Prints all the array self.data in an array.
         pub fn print(self: *@This()) void {
-            std.debug.print("\n  tensor data: ", .{});
+            std.log.debug("\n  tensor data: ", .{});
             for (0..self.size) |i| {
-                std.debug.print("{} ", .{self.data[i]});
+                std.log.debug("{} ", .{self.data[i]});
             }
-            std.debug.print("\n", .{});
+            std.log.debug("\n", .{});
         }
 
         /// Print the Tensor() to console in a more readable way.
@@ -572,29 +572,29 @@ pub fn Tensor(comptime T: type) type {
         fn _printMultidimHelper(self: *@This(), offset: usize, idx: usize) void {
             // Print opening bracket with a number of tab that is equals to idx
             for (0..idx) |_| {
-                std.debug.print("    ", .{});
+                std.log.debug("    ", .{});
             }
-            std.debug.print("[", .{});
+            std.log.debug("[", .{});
 
             if (idx == self.shape.len - 1) {
                 for (0..self.shape[self.shape.len - 1]) |i| {
                     const local_idx = offset + i;
-                    std.debug.print("{}, ", .{self.data[local_idx]});
+                    std.log.debug("{}, ", .{self.data[local_idx]});
                 }
-                std.debug.print("],\n", .{});
+                std.log.debug("],\n", .{});
             } else {
-                std.debug.print("\n", .{});
+                std.log.debug("\n", .{});
                 for (0..self.shape[idx]) |i| {
                     self._printMultidimHelper(offset + self.shape[idx + 1] * i, idx + 1);
                 }
-                std.debug.print("\n", .{});
+                std.log.debug("\n", .{});
 
                 for (0..idx) |_| {
-                    std.debug.print("    ", .{});
+                    std.log.debug("    ", .{});
                 }
-                std.debug.print("]", .{});
+                std.log.debug("]", .{});
                 if (idx != 0) {
-                    std.debug.print(",\n", .{});
+                    std.log.debug(",\n", .{});
                 }
             }
         }

--- a/src/onnx/attributeProto.zig
+++ b/src/onnx/attributeProto.zig
@@ -6,6 +6,8 @@ const GraphProto = @import("graphProto.zig").GraphProto;
 const TypeProto = @import("typeProto.zig").TypeProto;
 const SparseTensorProto = @import("sparseTensorProto.zig").SparseTensorProto;
 
+const onnx_log = std.log.scoped(.attributeProto);
+
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
@@ -156,7 +158,7 @@ pub const AttributeProto = struct {
         while (reader.hasMore()) {
             const attr_tag = try reader.readTag();
             //DEBUG
-            //std.debug.print("Parsing attribute field {d} with wire type {}\n", .{ attr_tag.field_number, attr_tag.wire_type });
+            //onnx_log.debug("Parsing attribute field {d} with wire type {}\n", .{ attr_tag.field_number, attr_tag.wire_type });
             switch (attr_tag.field_number) {
                 1 => { // name
                     attr.name = try reader.readString(reader.allocator);
@@ -215,7 +217,7 @@ pub const AttributeProto = struct {
                     const v = try reader.readVarint();
                     try ints_list.append(@intCast(v));
                     //DEBUG
-                    //std.debug.print("Added int value {d} to {s}\n", .{ v, attr.name });
+                    //onnx_log.debug("Added int value {d} to {s}\n", .{ v, attr.name });
                     attr.type = .INTS;
                 },
                 9 => { // strings
@@ -270,7 +272,7 @@ pub const AttributeProto = struct {
                     if (attr.type != .INTS) attr.type = .SPARSE_TENSOR;
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for AttributeProto\n\n ", .{attr_tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for AttributeProto\n\n ", .{attr_tag});
 
                     try reader.skipField(attr_tag.wire_type);
                 },
@@ -289,105 +291,100 @@ pub const AttributeProto = struct {
         const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
             return;
         };
-        std.debug.print("{s}------------- ATTRIBUTE \n", .{space});
+        onnx_log.debug("{s}------------- ATTRIBUTE \n", .{space});
 
-        std.debug.print("{s}Name: {s}\n", .{ space, self.name });
-        std.debug.print("{s}Type: {}\n", .{ space, self.type });
+        onnx_log.debug("{s}Name: {s}\n", .{ space, self.name });
+        onnx_log.debug("{s}Type: {}\n", .{ space, self.type });
 
         if (self.f != 0) {
-            std.debug.print("{s}Float: {}\n", .{ space, self.f });
+            onnx_log.debug("{s}Float: {}\n", .{ space, self.f });
         }
 
         if (self.i != 0) {
-            std.debug.print("{s}Int: {}\n", .{ space, self.i });
+            onnx_log.debug("{s}Int: {}\n", .{ space, self.i });
         }
 
         if (self.s.len > 0) {
-            std.debug.print("{s}String: \"{s}\"\n", .{ space, self.s });
+            onnx_log.debug("{s}String: \"{s}\"\n", .{ space, self.s });
         }
 
         if (self.t) |tensor| {
-            std.debug.print("{s}Tensor:\n", .{space});
+            onnx_log.debug("{s}Tensor:\n", .{space});
             tensor.print(space);
         }
 
         if (self.g) |tensor| {
-            std.debug.print("{s}Tensor:\n", .{space});
+            onnx_log.debug("{s}Tensor:\n", .{space});
             tensor.print(space);
         }
 
         if (self.floats.len > 0) {
-            std.debug.print("{s}Floats: [", .{space});
-            for (self.floats, 0..) |val, i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("{}", .{val});
+            onnx_log.debug("{s}Floats: [", .{space});
+            for (self.floats) |val| {
+                onnx_log.debug("{}", .{val});
             }
-            std.debug.print("]\n", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.ints.len > 0) {
-            std.debug.print("{s}Ints: [", .{space});
-            for (self.ints, 0..) |val, i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("{}", .{val});
+            onnx_log.debug("{s}Ints: [", .{space});
+            for (self.ints) |val| {
+                onnx_log.debug("{}", .{val});
             }
-            std.debug.print("]\n", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.strings.len > 0) {
-            std.debug.print("{s}Strings: [", .{space});
-            for (self.strings, 0..) |val, i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("\"{s}\"", .{val});
+            onnx_log.debug("{s}Strings: [", .{space});
+            for (self.strings) |val| {
+                onnx_log.debug("\"{s}\"", .{val});
             }
-            std.debug.print("]\n", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.tensors.len > 0) {
-            std.debug.print("{s}Tensors: [", .{space});
-            for (self.tensors, 0..) |val, i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("TensorProto", .{});
+            onnx_log.debug("{s}Tensors: [", .{space});
+            for (self.tensors) |val| {
+                onnx_log.debug("TensorProto", .{});
                 val.print(space);
             }
-            std.debug.print("]\n", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         //if (self.graphs.len > 0) {
-        //   std.debug.print("{s}Graphs: [", .{space});
+        //   onnx_log.debug("{s}Graphs: [", .{space});
         // for (self.graphs, 0..) |val, i| {
-        //   if (i > 0) std.debug.print(", ", .{});
-        // std.debug.print("GraphProto", .{});
+        //   if (i > 0) onnx_log.debug(", ", .{});
+        // onnx_log.debug("GraphProto", .{});
         //val.print(space);
         //}
-        //std.debug.print("]\n", .{});
+        //onnx_log.debug("]\n", .{});
         //}
 
         if (self.doc_string) |doc| {
-            std.debug.print("{s}Doc String: \"{s}\"\n", .{ space, doc });
+            onnx_log.debug("{s}Doc String: \"{s}\"\n", .{ space, doc });
         }
 
         if (self.tp) |tp| {
-            std.debug.print("{s}TypeProto:\n", .{space});
+            onnx_log.debug("{s}TypeProto:\n", .{space});
             tp.print(space);
         }
 
         if (self.type_protos.len > 0) {
-            std.debug.print("{s}Type Protos: [", .{space});
-            for (self.type_protos, 0..) |val, i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("TypeProto", .{});
+            onnx_log.debug("{s}Type Protos: [", .{space});
+            for (self.type_protos) |val| {
+                onnx_log.debug("TypeProto", .{});
                 val.print(space);
             }
-            std.debug.print("]\n", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.ref_attr_name.len > 0) {
-            std.debug.print("{s}Ref Attr Name: \"{s}\"\n", .{ space, self.ref_attr_name });
+            onnx_log.debug("{s}Ref Attr Name: \"{s}\"\n", .{ space, self.ref_attr_name });
         }
 
         if (self.sparse_tensor) |tensor| {
-            std.debug.print("{s}Sparse Tensor:\n", .{space});
+            onnx_log.debug("{s}Sparse Tensor:\n", .{space});
             tensor.print(space);
         }
     }

--- a/src/onnx/functionProto.zig
+++ b/src/onnx/functionProto.zig
@@ -12,6 +12,8 @@ const OperatorSetIdProto = @import("onnx.zig").OperatorSetIdProto;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.functionProto);
+
 // onnx library reference: https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L909
 //TAGS:
 // - 1 : name, optional string
@@ -197,7 +199,7 @@ pub const FunctionProto = struct {
                     try metadataList.append(ssep_ptr);
                 },
                 else => {
-                    std.debug.print("\n\n ........default readLenghtDelimited, TAG:{any} \n", .{tag});
+                    onnx_log.debug("\n\n ........default readLenghtDelimited, TAG:{any} \n", .{tag});
 
                     var unknown_reader = try reader.readLengthDelimited();
                     while (unknown_reader.hasMore()) {
@@ -224,74 +226,71 @@ pub const FunctionProto = struct {
             return;
         };
 
-        std.debug.print("{s}------------- FUNCTION\n", .{space});
+        onnx_log.debug("{s}------------- FUNCTION\n", .{space});
 
         if (self.name) |n| {
-            std.debug.print("{s}Function Name: {s}\n", .{ space, n });
+            onnx_log.debug("{s}Function Name: {s}\n", .{ space, n });
         } else {
-            std.debug.print("{s}Function Name: (none)\n", .{space});
+            onnx_log.debug("{s}Function Name: (none)\n", .{space});
         }
 
-        std.debug.print("{s}Inputs: ", .{space});
-        for (self.input, 0..) |inp, i| {
-            if (i > 0) std.debug.print(", ", .{});
-            std.debug.print("{s}", .{inp});
+        onnx_log.debug("{s}Inputs: ", .{space});
+        for (self.input) |inp| {
+            onnx_log.debug("{s}", .{inp});
         }
-        std.debug.print("\n", .{});
+        onnx_log.debug("\n", .{});
 
-        std.debug.print("{s}Outputs: ", .{space});
-        for (self.output, 0..) |out, i| {
-            if (i > 0) std.debug.print(", ", .{});
-            std.debug.print("{s}{s} ", .{ space, out });
+        onnx_log.debug("{s}Outputs: ", .{space});
+        for (self.output) |out| {
+            onnx_log.debug("{s}{s} ", .{ space, out });
         }
-        std.debug.print("\n", .{});
+        onnx_log.debug("\n", .{});
 
-        std.debug.print("{s}Attributes: ", .{space});
-        for (self.attribute, 0..) |attr, i| {
-            if (i > 0) std.debug.print(", ", .{});
-            std.debug.print("{s}{s} ", .{ space, attr });
+        onnx_log.debug("{s}Attributes: ", .{space});
+        for (self.attribute) |attr| {
+            onnx_log.debug("{s}{s} ", .{ space, attr });
         }
-        std.debug.print("\n", .{});
+        onnx_log.debug("\n", .{});
 
-        std.debug.print("{s}Attributes Proto:\n", .{space});
+        onnx_log.debug("{s}Attributes Proto:\n", .{space});
         for (self.attribute_proto) |attr| {
             attr.print(space);
         }
 
-        std.debug.print("{s}Nodes:\n", .{space});
+        onnx_log.debug("{s}Nodes:\n", .{space});
         for (self.node) |node| {
             node.print(space);
         }
 
         if (self.doc_string) |ds| {
-            std.debug.print("{s}Function Doc string: {s}\n", .{ space, ds });
+            onnx_log.debug("{s}Function Doc string: {s}\n", .{ space, ds });
         } else {
-            std.debug.print("{s}Function Doc string: (none)\n", .{space});
+            onnx_log.debug("{s}Function Doc string: (none)\n", .{space});
         }
 
-        std.debug.print("{s}Opertor set id:\n", .{space});
+        onnx_log.debug("{s}Opertor set id:\n", .{space});
         for (self.opset_import) |opset| {
             opset.print(space);
         }
 
         if (self.domain) |d| {
-            std.debug.print("{s}Function Domain: {s}\n", .{ space, d });
+            onnx_log.debug("{s}Function Domain: {s}\n", .{ space, d });
         } else {
-            std.debug.print("{s}Function Domain: (none)\n", .{space});
+            onnx_log.debug("{s}Function Domain: (none)\n", .{space});
         }
 
         if (self.overload) |o| {
-            std.debug.print("{s}Function Overload: {s}\n", .{ space, o });
+            onnx_log.debug("{s}Function Overload: {s}\n", .{ space, o });
         } else {
-            std.debug.print("{s}Function Overload: (none)\n", .{space});
+            onnx_log.debug("{s}Function Overload: (none)\n", .{space});
         }
 
-        std.debug.print("{s}value infos (key, value) [{}]: \n", .{ space, self.metadata_props.len });
+        onnx_log.debug("{s}value infos (key, value) [{}]: \n", .{ space, self.metadata_props.len });
         for (self.value_info) |vi| {
             vi.print(space);
         }
 
-        std.debug.print("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
+        onnx_log.debug("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
         for (self.metadata_props) |mp| {
             mp.print(space);
         }

--- a/src/onnx/graphProto.zig
+++ b/src/onnx/graphProto.zig
@@ -11,6 +11,8 @@ const SparseTensorProto = @import("sparseTensorProto.zig").SparseTensorProto;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.graphProto);
+
 // onnx library reference: https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L460
 //TAGS:
 //  - 1 : node, type: NodeProto repeated
@@ -180,7 +182,7 @@ pub const GraphProto = struct {
                     try metadataList.append(ssep_ptr);
                 },
                 else => {
-                    //std.debug.print("\n\n ........default readLenghtDelimited, TAG:{any} \n", .{tag});
+                    //onnx_log.debug("\n\n ........default readLenghtDelimited, TAG:{any} \n", .{tag});
 
                     var unknown_reader = try reader.readLengthDelimited();
                     while (unknown_reader.hasMore()) {
@@ -207,50 +209,50 @@ pub const GraphProto = struct {
             return;
         };
 
-        std.debug.print("{s}------------- GRAPH\n", .{space});
+        onnx_log.info("{s}------------- GRAPH\n", .{space});
 
         if (self.name) |n| {
-            std.debug.print("{s}Graph Name: {s}\n", .{ space, n });
+            onnx_log.info("{s}Graph Name: {s}\n", .{ space, n });
         } else {
-            std.debug.print("{s}Graph Name: (none)\n", .{space});
+            onnx_log.info("{s}Graph Name: (none)\n", .{space});
         }
 
-        std.debug.print("{s}Nodes:\n", .{space});
+        onnx_log.debug("{s}Nodes:\n", .{space});
         for (self.nodes) |node| {
             node.print(space);
         }
 
-        std.debug.print("{s}Initializers  [{}]:\n", .{ space, self.initializers.len });
+        onnx_log.debug("{s}Initializers  [{}]:\n", .{ space, self.initializers.len });
         for (self.initializers) |initializer| {
             initializer.print(space);
         }
 
-        std.debug.print("{s}Inputs [{}]:\n", .{ space, self.inputs.len });
+        onnx_log.debug("{s}Inputs [{}]:\n", .{ space, self.inputs.len });
         for (self.inputs) |input| {
             input.print(space);
         }
 
-        std.debug.print("{s}Outputs  [{}]: \n", .{ space, self.outputs.len });
+        onnx_log.debug("{s}Outputs  [{}]: \n", .{ space, self.outputs.len });
         for (self.outputs) |output| {
             output.print(space);
         }
 
-        std.debug.print("{s}Value_info [{}]:\n", .{ space, self.value_info.len });
+        onnx_log.debug("{s}Value_info [{}]:\n", .{ space, self.value_info.len });
         for (self.value_info) |vi| {
             vi.print(space);
         }
 
-        std.debug.print("{s}Quantization Annotations:\n", .{space});
+        onnx_log.debug("{s}Quantization Annotations:\n", .{space});
         for (self.quantization_annotation) |qa| {
             qa.print(space);
         }
 
-        std.debug.print("{s}Sparse Initializers:\n", .{space});
+        onnx_log.debug("{s}Sparse Initializers:\n", .{space});
         for (self.sparse_initializer) |sp| {
             sp.print(space);
         }
 
-        std.debug.print("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
+        onnx_log.debug("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
         for (self.metadata_props) |mp| {
             mp.print(space);
         }

--- a/src/onnx/modelProto.zig
+++ b/src/onnx/modelProto.zig
@@ -9,6 +9,8 @@ const FunctionProto = @import("onnx.zig").FunctionProto;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.modelProto);
+
 // onnx library reference: https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L361
 // TAGS:
 //  - 1 : ir_version, optional int64
@@ -153,7 +155,7 @@ pub const ModelProto = struct {
                     try functions.append(fn_ptr);
                 },
                 else => {
-                    std.debug.print("\n\n ........default readLenghtDelimited, TAG:{any} \n", .{tag});
+                    onnx_log.debug("\n\n ........default readLenghtDelimited, TAG:{any} \n", .{tag});
                     try reader.skipField(tag.wire_type);
                 },
             }
@@ -167,59 +169,59 @@ pub const ModelProto = struct {
     }
 
     pub fn print(self: *ModelProto) void {
-        std.debug.print("\n\n------------------------- MODEL -------------------------------\n", .{});
+        onnx_log.info("\n\n------------------------- MODEL -------------------------------\n", .{});
 
-        std.debug.print("ModelProto:\n", .{});
-        std.debug.print("  IR Version: {}\n", .{self.ir_version});
+        onnx_log.debug("ModelProto:\n", .{});
+        onnx_log.debug("  IR Version: {}\n", .{self.ir_version});
 
         if (self.producer_name) |name| {
-            std.debug.print("  Producer Name: {s}\n", .{name});
+            onnx_log.debug("  Producer Name: {s}\n", .{name});
         } else {
-            std.debug.print("  Producer Name: (none)\n", .{});
+            onnx_log.debug("  Producer Name: (none)\n", .{});
         }
 
         if (self.producer_version) |version| {
-            std.debug.print("  Producer Version: {s}\n", .{version});
+            onnx_log.debug("  Producer Version: {s}\n", .{version});
         } else {
-            std.debug.print("  Producer Version: (none)\n", .{});
+            onnx_log.debug("  Producer Version: (none)\n", .{});
         }
 
         if (self.domain) |d| {
-            std.debug.print("  Domain: {s}\n", .{d});
+            onnx_log.debug("  Domain: {s}\n", .{d});
         } else {
-            std.debug.print("  Domain: (none)\n", .{});
+            onnx_log.debug("  Domain: (none)\n", .{});
         }
 
         if (self.model_version) |v| {
-            std.debug.print("  Model Version: {}\n", .{v});
+            onnx_log.debug("  Model Version: {}\n", .{v});
         } else {
-            std.debug.print("  Model Version: (none)\n", .{});
+            onnx_log.debug("  Model Version: (none)\n", .{});
         }
 
         if (self.doc_string) |doc| {
-            std.debug.print("  Doc String: {s}\n", .{doc});
+            onnx_log.debug("  Doc String: {s}\n", .{doc});
         } else {
-            std.debug.print("  Doc String: (none)\n", .{});
+            onnx_log.debug("  Doc String: (none)\n", .{});
         }
 
         if (self.graph) |g| {
-            std.debug.print("  Graph:\n", .{});
+            onnx_log.debug("  Graph:\n", .{});
             g.print(null);
         } else {
-            std.debug.print("  Graph: (none)\n", .{});
+            onnx_log.debug("  Graph: (none)\n", .{});
         }
 
-        std.debug.print("{s}Operator set id:\n", .{" "});
+        onnx_log.debug("{s}Operator set id:\n", .{" "});
         for (self.opset_import) |opset| {
             opset.print(null);
         }
 
-        std.debug.print("Metadata count: {}\n", .{self.metadata_props.len});
+        onnx_log.debug("Metadata count: {}\n", .{self.metadata_props.len});
         for (self.metadata_props) |metadata| {
             metadata.print(null);
         }
 
-        std.debug.print("Functions count: {}\n", .{self.functions.len});
+        onnx_log.debug("Functions count: {}\n", .{self.functions.len});
         for (self.functions) |fun| {
             fun.print(null);
         }

--- a/src/onnx/nodeProto.zig
+++ b/src/onnx/nodeProto.zig
@@ -8,6 +8,8 @@ const StringStringEntryProto = @import("onnx.zig").StringStringEntryProto;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.nodeProto);
+
 //onnx library reference: https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L212
 //TAGS:
 //  - 1 : input, repeated string
@@ -126,7 +128,7 @@ pub const NodeProto = struct {
                     try metadataList.append(ssep_ptr);
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for NodeProto\n\n", .{tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for NodeProto\n\n", .{tag});
                     try reader.skipField(tag.wire_type);
                 },
             }
@@ -144,42 +146,42 @@ pub const NodeProto = struct {
             return;
         };
 
-        std.debug.print("{s}------------- NODE\n", .{space});
+        onnx_log.info("{s}------------- NODE\n", .{space});
 
         if (self.name) |n| {
-            std.debug.print("{s}Name: {s}\n", .{ space, n });
+            onnx_log.info("{s}Name: {s}\n", .{ space, n });
         } else {
-            std.debug.print("{s}Name: (none)\n", .{space});
+            onnx_log.info("{s}Name: (none)\n", .{space});
         }
 
-        std.debug.print("{s}Op Type: {s}\n", .{ space, self.op_type });
+        onnx_log.info("{s}Op Type: {s}\n", .{ space, self.op_type });
 
         if (self.domain) |d| {
-            std.debug.print("{s}Domain: {s}\n", .{ space, d });
+            onnx_log.debug("{s}Domain: {s}\n", .{ space, d });
         } else {
-            std.debug.print("{s}Domain: (none)\n", .{space});
+            onnx_log.debug("{s}Domain: (none)\n", .{space});
         }
 
-        std.debug.print("{s}Inputs: ", .{space});
-        for (self.input, 0..) |inp, i| {
-            if (i > 0) std.debug.print(", ", .{});
-            std.debug.print("{s}", .{if (std.mem.eql(u8, inp, "")) "<empty_string>" else inp});
+        onnx_log.debug("{s}Inputs: ", .{space});
+        for (
+            self.input,
+        ) |inp| {
+            onnx_log.debug("{s}", .{if (std.mem.eql(u8, inp, "")) "<empty_string>" else inp});
         }
-        std.debug.print("\n", .{});
+        onnx_log.debug("\n", .{});
 
-        std.debug.print("{s}Outputs: ", .{space});
-        for (self.output, 0..) |out, i| {
-            if (i > 0) std.debug.print(", ", .{});
-            std.debug.print("{s}{s} ", .{ space, out });
+        onnx_log.debug("{s}Outputs: ", .{space});
+        for (self.output) |out| {
+            onnx_log.debug("{s}{s} ", .{ space, out });
         }
-        std.debug.print("\n", .{});
+        onnx_log.debug("\n", .{});
 
-        std.debug.print("{s}Attributes:\n", .{space});
+        onnx_log.debug("{s}Attributes:\n", .{space});
         for (self.attribute) |attr| {
             attr.print(space);
         }
 
-        std.debug.print("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
+        onnx_log.debug("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
         for (self.metadata_props) |mp| {
             mp.print(space);
         }

--- a/src/onnx/onnx.zig
+++ b/src/onnx/onnx.zig
@@ -18,6 +18,8 @@ pub const FunctionProto = @import("functionProto.zig").FunctionProto;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.onnx);
+
 pub const Version = enum(i64) {
     IR_VERSION_2017_10_10 = 0x0000000000000001,
     IR_VERSION_2017_10_30 = 0x0000000000000002,
@@ -122,7 +124,7 @@ pub fn tensorSizeInBytes(tensor: *const TensorProto) usize {
         .DOUBLE, .INT64, .UINT64, .COMPLEX64 => 8, // 8-byte types
         .COMPLEX128 => 16, // 16-byte types
         else => {
-            std.debug.print("Warning: Unknown data type {} in tensor, assuming 4 bytes per element\n", .{tensor.data_type});
+            onnx_log.warn("Warning: Unknown data type {} in tensor, assuming 4 bytes per element\n", .{tensor.data_type});
             return 4 * num_elements; // Default to 4 bytes for unknown types
         },
     };

--- a/src/onnx/operatorSetIdProto.zig
+++ b/src/onnx/operatorSetIdProto.zig
@@ -9,6 +9,8 @@ var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 // - 1 : domain, optional string
 // - 2 : version, optional int 64
 
+const onnx_log = std.log.scoped(.operatorSetIdProto);
+
 pub const OperatorSetIdProto = struct {
     domain: ?[]const u8,
     version: ?i64,
@@ -34,7 +36,7 @@ pub const OperatorSetIdProto = struct {
                     idProto.version = @as(i64, @intCast(value));
                 },
                 else => {
-                    std.debug.print("\n\n ........default readLenghtDelimited, TAG:{any} \n", .{tag});
+                    onnx_log.info("\n\n ........default readLenghtDelimited, TAG:{any} \n", .{tag});
                     try reader.skipField(tag.wire_type);
                 },
             }
@@ -48,18 +50,18 @@ pub const OperatorSetIdProto = struct {
             return;
         };
 
-        std.debug.print("{s}------------- OPERATOR SET ID PROTO\n", .{space});
+        onnx_log.debug("{s}------------- OPERATOR SET ID PROTO\n", .{space});
 
         if (self.domain) |d| {
-            std.debug.print("{s}OperatorSetID domain: {s}\n", .{ space, d });
+            onnx_log.debug("{s}OperatorSetID domain: {s}\n", .{ space, d });
         } else {
-            std.debug.print("{s}OperatorSetID domain: (none)\n", .{space});
+            onnx_log.debug("{s}OperatorSetID domain: (none)\n", .{space});
         }
 
         if (self.version) |v| {
-            std.debug.print("{s}OperatorSetID version: {}\n", .{ space, v });
+            onnx_log.debug("{s}OperatorSetID version: {}\n", .{ space, v });
         } else {
-            std.debug.print("{s}OperatorSetID version: (none)\n", .{space});
+            onnx_log.debug("{s}OperatorSetID version: (none)\n", .{space});
         }
     }
 };

--- a/src/onnx/protobuf.zig
+++ b/src/onnx/protobuf.zig
@@ -181,7 +181,7 @@ pub const ProtoReader = struct {
             },
             .Fixed32 => try self.skip(4),
             else => {
-                std.debug.print("\n ERROR! wire type {any} not supported", .{wire_type});
+                std.log.scoped(.protobuf).warn("\n ERROR! wire type {any} not supported", .{wire_type});
                 unreachable;
                 //return error.UnsupportedWireType;
             },

--- a/src/onnx/segment.zig
+++ b/src/onnx/segment.zig
@@ -4,6 +4,8 @@ const protobuf = @import("protobuf.zig");
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.segment);
+
 // onnx library reference: https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L503
 
 //TAGS:
@@ -32,7 +34,7 @@ pub const Segment = struct {
                     segment.end = @intCast(value);
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for AttributeProto\n\n ", .{seg_tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for AttributeProto\n\n ", .{seg_tag});
                     try reader.skipField(seg_tag.wire_type);
                 },
             }
@@ -45,18 +47,18 @@ pub const Segment = struct {
             return;
         };
 
-        std.debug.print("{s}------------- SEGMENT\n", .{space});
+        onnx_log.debug("{s}------------- SEGMENT\n", .{space});
 
         if (self.begin) |b| {
-            std.debug.print("{s}Segment begin: {}\n", .{ space, b });
+            onnx_log.debug("{s}Segment begin: {}\n", .{ space, b });
         } else {
-            std.debug.print("{s}Segment begin: (none)\n", .{space});
+            onnx_log.debug("{s}Segment begin: (none)\n", .{space});
         }
 
         if (self.end) |e| {
-            std.debug.print("{s}Segment end: {}\n", .{ space, e });
+            onnx_log.debug("{s}Segment end: {}\n", .{ space, e });
         } else {
-            std.debug.print("{s}Segment end: (none)\n", .{space});
+            onnx_log.debug("{s}Segment end: (none)\n", .{space});
         }
     }
 };

--- a/src/onnx/sparseTensorProto.zig
+++ b/src/onnx/sparseTensorProto.zig
@@ -6,6 +6,8 @@ const TensorProto = @import("tensorProto.zig").TensorProto;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.tensorProto);
+
 // onnx library reference: https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L460
 
 //TAGS:
@@ -61,7 +63,7 @@ pub const SparseTensorProto = struct {
                     try dim_list.append(@intCast(d));
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for sparseTensorProto\n\n ", .{sp_tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for sparseTensorProto\n\n ", .{sp_tag});
                     try reader.skipField(sp_tag.wire_type);
                 },
             }
@@ -76,25 +78,25 @@ pub const SparseTensorProto = struct {
             return;
         };
 
-        std.debug.print("{s}------------- SparseTensorProto\n", .{space});
+        onnx_log.debug("{s}------------- SparseTensorProto\n", .{space});
 
         if (self.values) |tensor| {
-            std.debug.print("{s}TensorProto:\n", .{space});
+            onnx_log.debug("{s}TensorProto:\n", .{space});
             tensor.print(space);
         }
 
         if (self.indices) |tensor| {
-            std.debug.print("{s}TensorProto:\n", .{space});
+            onnx_log.debug("{s}TensorProto:\n", .{space});
             tensor.print(space);
         }
 
         if (self.dims.len > 0) {
-            std.debug.print("{s}Dims: [", .{space});
+            onnx_log.debug("{s}Dims: [", .{space});
             for (self.dims, 0..) |val, i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("{}", .{val});
+                if (i > 0) onnx_log.debug(", ", .{});
+                onnx_log.debug("{}", .{val});
             }
-            std.debug.print("]\n", .{});
+            onnx_log.debug("]\n", .{});
         }
     }
 };

--- a/src/onnx/stringStringEntryProto.zig
+++ b/src/onnx/stringStringEntryProto.zig
@@ -6,6 +6,8 @@ const DataType = @import("onnx.zig").DataType;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.stringEntryProto);
+
 // onnx library reference: https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L531
 // TAGS:
 //  - 1 : key, optional string
@@ -35,7 +37,7 @@ pub const StringStringEntryProto = struct {
                     ssep.value = try reader.readString(reader.allocator);
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for StringStringEntryProto\n\n", .{tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for StringStringEntryProto\n\n", .{tag});
                     return error.TagNotAvailable;
                 },
             }
@@ -49,7 +51,7 @@ pub const StringStringEntryProto = struct {
             return;
         };
 
-        std.debug.print("{s}StringStringEntryProto: key:{s}, value:{s} \n", .{
+        onnx_log.info("{s}StringStringEntryProto: key:{s}, value:{s} \n", .{
             space,
             if (self.key) |k| k else "(none)",
             if (self.value) |v| v else "(none)",

--- a/src/onnx/tensorAnnotation.zig
+++ b/src/onnx/tensorAnnotation.zig
@@ -5,6 +5,8 @@ const protobuf = @import("protobuf.zig");
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.tensorAnnotation);
+
 // https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L536
 //
 //TAG:
@@ -42,14 +44,14 @@ pub const TensorAnnotation = struct {
                     tensor.tensor_name = str;
                 },
                 2 => {
-                    std.debug.print("\n ................ TensorAnnotation READING  quant_parameter_tensor_names", .{});
+                    onnx_log.info("\n ................ TensorAnnotation READING  quant_parameter_tensor_names", .{});
                     var md_reader = try reader.readLengthDelimited(); //var md_reader
                     const ssep_ptr = try reader.allocator.create(StringStringEntryProto);
                     ssep_ptr.* = try StringStringEntryProto.parse(&md_reader);
                     try tensorNamesList.append(ssep_ptr);
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for AttributeProto\n\n ", .{tensor_tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for AttributeProto\n\n ", .{tensor_tag});
                     try reader.skipField(tensor_tag.wire_type);
                 },
             }
@@ -64,15 +66,15 @@ pub const TensorAnnotation = struct {
             return;
         };
 
-        std.debug.print("{s}------------- TensorAnnotation\n", .{space});
+        onnx_log.debug("{s}------------- TensorAnnotation\n", .{space});
 
         if (self.tensor_name) |n| {
-            std.debug.print("{s}Tensor Name: {s}\n", .{ space, n });
+            onnx_log.debug("{s}Tensor Name: {s}\n", .{ space, n });
         } else {
-            std.debug.print("{s}Tensor Name: (none)\n", .{space});
+            onnx_log.debug("{s}Tensor Name: (none)\n", .{space});
         }
 
-        std.debug.print("{s}quant_parameter_tensor_names (key, value) [{}]: \n", .{ space, self.quant_parameter_tensor_names.len });
+        onnx_log.debug("{s}quant_parameter_tensor_names (key, value) [{}]: \n", .{ space, self.quant_parameter_tensor_names.len });
         for (self.quant_parameter_tensor_names) |mp| {
             mp.print(space);
         }

--- a/src/onnx/tensorProto.zig
+++ b/src/onnx/tensorProto.zig
@@ -9,6 +9,8 @@ const Segment = @import("segment.zig").Segment;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.tensorProto);
+
 // onnx library reference: https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L503
 //TAGS:
 //  - 1 : dims, repeated int64
@@ -248,7 +250,7 @@ pub const TensorProto = struct {
                     try metaDataList.append(ssep_ptr);
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for TensorProto\n\n", .{tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for TensorProto\n\n", .{tag});
                     try reader.skipField(tag.wire_type);
                 },
             }
@@ -263,115 +265,108 @@ pub const TensorProto = struct {
 
         return tensor;
     }
-
     pub fn print(self: *TensorProto, padding: ?[]const u8) void {
         const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
             return;
         };
 
-        std.debug.print("{s}------------- TENSOR\n", .{space});
+        onnx_log.info("{s}------------- TENSOR\n", .{space});
 
         if (self.name) |n| {
-            std.debug.print("{s}Name: {s}\n", .{ space, n });
+            onnx_log.info("{s}Name: {s}\n", .{ space, n });
         } else {
-            std.debug.print("{s}Name: (none)\n", .{space});
+            onnx_log.info("{s}Name: (none)\n", .{space});
         }
 
         if (self.segment) |segment| {
-            std.debug.print("{s}Segment:\n", .{space});
+            onnx_log.debug("{s}Segment:\n", .{space});
             segment.print(space);
         }
 
-        std.debug.print("{s}Data Type: {any}\n", .{ space, self.data_type });
+        onnx_log.debug("{s}Data Type: {any}\n", .{ space, self.data_type });
 
-        std.debug.print("{s}Dims: [", .{space});
-        for (self.dims, 0..) |dim, i| {
-            if (i > 0) std.debug.print(", ", .{});
-            std.debug.print("{}", .{dim});
+        onnx_log.debug("{s}Dims: [", .{space});
+        for (
+            self.dims,
+        ) |dim| {
+            onnx_log.debug("{}", .{dim});
         }
-        std.debug.print("]\n", .{});
+        onnx_log.debug("]\n", .{});
 
         if (self.raw_data) |raw| {
-            std.debug.print("{s}Raw Data: {} bytes\n", .{ space, raw.len });
+            onnx_log.debug("{s}Raw Data: {} bytes\n", .{ space, raw.len });
         }
 
         if (self.float_data) |data| {
-            std.debug.print("{s}Float Data: [", .{space});
+            onnx_log.debug("{s}Float Data: [", .{space});
             for (0..if (data.len < 10) data.len else 10) |i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("{}", .{data[i]});
+                onnx_log.debug("{}", .{data[i]});
             }
-            if (data.len >= 10) std.debug.print(", ... ", .{});
-            std.debug.print("]\n", .{});
+            if (data.len >= 10) onnx_log.debug(", ... ", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.int32_data) |data| {
-            std.debug.print("{s}Int32 Data: [", .{space});
+            onnx_log.debug("{s}Int32 Data: [", .{space});
             for (0..if (data.len < 10) data.len else 10) |i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("{}", .{data[i]});
+                onnx_log.debug("{}", .{data[i]});
             }
-            if (data.len >= 10) std.debug.print(", ... ", .{});
-            std.debug.print("]\n", .{});
+            if (data.len >= 10) onnx_log.debug(", ... ", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.int64_data) |data| {
-            std.debug.print("{s}Int64 Data: [", .{space});
+            onnx_log.debug("{s}Int64 Data: [", .{space});
             for (0..if (data.len < 10) data.len else 10) |i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("{}", .{data[i]});
+                onnx_log.debug("{}", .{data[i]});
             }
-            if (data.len >= 10) std.debug.print(", ... ", .{});
-            std.debug.print("]\n", .{});
+            if (data.len >= 10) onnx_log.debug(", ... ", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.double_data) |data| {
-            std.debug.print("{s}Double Data: [", .{space});
+            onnx_log.debug("{s}Double Data: [", .{space});
             for (0..if (data.len < 10) data.len else 10) |i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("{}", .{data[i]});
+                onnx_log.debug("{}", .{data[i]});
             }
-            if (data.len >= 10) std.debug.print(", ... ", .{});
-            std.debug.print("]\n", .{});
+            if (data.len >= 10) onnx_log.debug(", ... ", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.uint64_data) |data| {
-            std.debug.print("{s}UInt64 Data: [", .{space});
+            onnx_log.debug("{s}UInt64 Data: [", .{space});
             for (0..if (data.len < 10) data.len else 10) |i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("{}", .{data[i]});
+                onnx_log.debug("{}", .{data[i]});
             }
-            if (data.len >= 10) std.debug.print(", ... ", .{});
-            std.debug.print("]\n", .{});
+            if (data.len >= 10) onnx_log.debug(", ... ", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.uint16_data) |data| {
-            std.debug.print("{s}UInt16 Data: [", .{space});
+            onnx_log.debug("{s}UInt16 Data: [", .{space});
             for (0..if (data.len < 10) data.len else 10) |i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("{}", .{data[i]});
+                onnx_log.debug("{}", .{data[i]});
             }
-            if (data.len >= 10) std.debug.print(", ... ", .{});
-            std.debug.print("]\n", .{});
+            if (data.len >= 10) onnx_log.debug(", ... ", .{});
+            onnx_log.debug("]\n", .{});
         }
 
         if (self.string_data) |data| {
-            std.debug.print("  String Data: [", .{});
-            for (data, 0..) |val, i| {
-                if (i > 0) std.debug.print(", ", .{});
-                std.debug.print("\"{s}\"", .{val});
+            onnx_log.debug("  String Data: [", .{});
+            for (data) |val| {
+                onnx_log.debug("\"{s}\"", .{val});
             }
-            std.debug.print("]\n", .{});
+            onnx_log.debug("]\n", .{});
         }
 
-        std.debug.print("{s}External Data (key, value) [{}]: \n", .{ space, self.external_data.len });
+        onnx_log.debug("{s}External Data (key, value) [{}]: \n", .{ space, self.external_data.len });
         for (self.external_data) |ex| {
             ex.print(space);
         }
 
-        std.debug.print("{s}Data Location: {any}\n", .{ space, self.data_location });
+        onnx_log.debug("{s}Data Location: {any}\n", .{ space, self.data_location });
 
-        std.debug.print("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
+        onnx_log.debug("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
         for (self.metadata_props) |mp| {
             mp.print(space);
         }
@@ -441,7 +436,7 @@ pub const TensorProto = struct {
                 self.uint16_data = typed_data;
             },
             else => {
-                std.debug.print("\n Data type conversion not supported for {s}, keeping raw data \n", .{@tagName(data_type)});
+                onnx_log.warn("\n Data type conversion not supported for {s}, keeping raw data \n", .{@tagName(data_type)});
                 // If conversion is not supported, we keep the raw_data.
                 // We need to prevent the deferred free.
                 free_raw_data = false;

--- a/src/onnx/tensorShapeProto.zig
+++ b/src/onnx/tensorShapeProto.zig
@@ -5,6 +5,8 @@ const AttributeType = @import("onnx.zig").AttributeType;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.tensorProto);
+
 //https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L700
 //The struct Dimension is not present, instead the dimensions are saved inside .dims
 //TAGS:
@@ -45,7 +47,7 @@ pub const TensorShapeProto = struct {
                         dim.dim_param = try reader.readString(reader.allocator);
                     },
                     else => {
-                        std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for Dimension\n\n ", .{tag});
+                        onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for Dimension\n\n ", .{tag});
                         try reader.skipField(tag.wire_type);
                     },
                 }
@@ -58,24 +60,24 @@ pub const TensorShapeProto = struct {
             const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
                 return;
             };
-            std.debug.print("{s}------------- DIMENSION\n", .{space});
+            onnx_log.debug("{s}------------- DIMENSION\n", .{space});
 
             if (self.dim_value) |value| {
-                std.debug.print("{s}Dim Value: {}\n", .{ space, value });
+                onnx_log.debug("{s}Dim Value: {}\n", .{ space, value });
             } else {
-                std.debug.print("{s}Dim Value: (none)\n", .{space});
+                onnx_log.debug("{s}Dim Value: (none)\n", .{space});
             }
 
             if (self.dim_param) |param| {
-                std.debug.print("{s}Dim Param: {s}\n", .{ space, param });
+                onnx_log.debug("{s}Dim Param: {s}\n", .{ space, param });
             } else {
-                std.debug.print("{s}Dim Param: (none)\n", .{space});
+                onnx_log.debug("{s}Dim Param: (none)\n", .{space});
             }
 
             if (self.denotation) |d| {
-                std.debug.print("{s}Denotation: {s}\n", .{ space, d });
+                onnx_log.debug("{s}Denotation: {s}\n", .{ space, d });
             } else {
-                std.debug.print("{s}Denotation: (none)\n", .{space});
+                onnx_log.debug("{s}Denotation: (none)\n", .{space});
             }
         }
     };
@@ -113,7 +115,7 @@ pub const TensorShapeProto = struct {
                     try dims_list.append(dim_ptr);
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for TensorShapeProto\n\n ", .{tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for TensorShapeProto\n\n ", .{tag});
                     try reader.skipField(tag.wire_type);
                 },
             }
@@ -136,20 +138,19 @@ pub const TensorShapeProto = struct {
         const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
             return;
         };
-        std.debug.print("{s}------------- SHAPE\n", .{space});
+        onnx_log.debug("{s}------------- SHAPE\n", .{space});
 
-        std.debug.print("{s}Shape: [", .{space});
-        for (self.shape, 0..) |dim, i| {
-            if (i > 0) std.debug.print(", ", .{});
-            std.debug.print("{}", .{dim});
+        onnx_log.debug("{s}Shape: [", .{space});
+        for (self.shape) |dim| {
+            onnx_log.debug("{}", .{dim});
         }
-        std.debug.print("]\n", .{});
+        onnx_log.debug("]\n", .{});
 
         if (self.dims.len != 0) {
-            std.debug.print("{s}Dimensions:\n", .{space});
+            onnx_log.debug("{s}Dimensions:\n", .{space});
             for (self.dims) |d| d.print(space);
         } else {
-            std.debug.print("{s}Dimensions: (none)\n", .{space});
+            onnx_log.debug("{s}Dimensions: (none)\n", .{space});
         }
     }
 };

--- a/src/onnx/typeProto.zig
+++ b/src/onnx/typeProto.zig
@@ -6,6 +6,8 @@ const TensorShapeProto = @import("onnx.zig").TensorShapeProto;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.typeProto);
+
 //https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L719
 //TAG oneof:
 //  - 1: tensor_type, type: TypeProto.Tensor
@@ -51,7 +53,7 @@ pub const TypeProto = struct {
                         tensor.shape = shape_ptr;
                     },
                     else => {
-                        std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for TensorProto\n\n", .{tag});
+                        onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for TensorProto\n\n", .{tag});
                         try reader.skipField(tag.wire_type);
                     },
                 }
@@ -64,15 +66,15 @@ pub const TypeProto = struct {
             const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
                 return;
             };
-            std.debug.print("{s}------------- TENSOR_TYPE\n", .{space});
+            onnx_log.debug("{s}------------- TENSOR_TYPE\n", .{space});
 
-            std.debug.print("{s}Element Type: {}\n", .{ space, self.elem_type });
+            onnx_log.debug("{s}Element Type: {}\n", .{ space, self.elem_type });
 
             if (self.shape) |s| {
-                std.debug.print("{s}Shape:\n", .{space});
+                onnx_log.debug("{s}Shape:\n", .{space});
                 s.print(space);
             } else {
-                std.debug.print("{s}Shape: (none)\n", .{space});
+                onnx_log.debug("{s}Shape: (none)\n", .{space});
             }
         }
     };
@@ -107,7 +109,7 @@ pub const TypeProto = struct {
                         // sequence.elem_type = elem_type_ptr;
                     },
                     else => {
-                        std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for ", .{tag});
+                        onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for ", .{tag});
                         unreachable;
                     },
                 }
@@ -120,13 +122,13 @@ pub const TypeProto = struct {
             const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
                 return;
             };
-            std.debug.print("{s}------------- SEQUENCE\n", .{space});
+            onnx_log.debug("{s}------------- SEQUENCE\n", .{space});
 
             if (self.elem_type) |t| {
-                std.debug.print("{s}Element Type:\n", .{space});
+                onnx_log.debug("{s}Element Type:\n", .{space});
                 t.print(space);
             } else {
-                std.debug.print("{s}Element Type: (none)\n", .{space});
+                onnx_log.debug("{s}Element Type: (none)\n", .{space});
             }
         }
     };
@@ -166,7 +168,7 @@ pub const TypeProto = struct {
                         // map.value_type = value_ptr;
                     },
                     else => {
-                        std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE ", .{tag});
+                        onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE ", .{tag});
                         unreachable;
                     },
                 }
@@ -179,15 +181,15 @@ pub const TypeProto = struct {
             const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
                 return;
             };
-            std.debug.print("{s}------------- MAP\n", .{space});
+            onnx_log.debug("{s}------------- MAP\n", .{space});
 
-            std.debug.print("{s}Key Type: {}\n", .{ space, self.key_type });
+            onnx_log.debug("{s}Key Type: {}\n", .{ space, self.key_type });
 
             if (self.value_type) |v| {
-                std.debug.print("{s}Value Type:\n", .{space});
+                onnx_log.debug("{s}Value Type:\n", .{space});
                 v.print(space);
             } else {
-                std.debug.print("{s}Value Type: (none)\n", .{space});
+                onnx_log.debug("{s}Value Type: (none)\n", .{space});
             }
         }
     };
@@ -229,7 +231,7 @@ pub const TypeProto = struct {
                         sparse_tensor.shape = shape_ptr;
                     },
                     else => {
-                        std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE ", .{tag});
+                        onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE ", .{tag});
                         unreachable;
                     },
                 }
@@ -242,14 +244,14 @@ pub const TypeProto = struct {
             const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
                 return;
             };
-            std.debug.print("{s}------------- SparseTensor\n", .{space});
-            std.debug.print("{s}Element Type: {}\n", .{ space, self.elem_type });
+            onnx_log.debug("{s}------------- SparseTensor\n", .{space});
+            onnx_log.debug("{s}Element Type: {}\n", .{ space, self.elem_type });
 
             if (self.shape) |s| {
-                std.debug.print("{s}Shape:\n", .{space});
+                onnx_log.debug("{s}Shape:\n", .{space});
                 s.print(space);
             } else {
-                std.debug.print("{s}Shape: (none)\n", .{space});
+                onnx_log.debug("{s}Shape: (none)\n", .{space});
             }
         }
     };
@@ -284,7 +286,7 @@ pub const TypeProto = struct {
                         //opt.elem_type = elm_ptr;
                     },
                     else => {
-                        std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE ", .{tag});
+                        onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE ", .{tag});
                         unreachable;
                     },
                 }
@@ -297,12 +299,12 @@ pub const TypeProto = struct {
             const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
                 return;
             };
-            std.debug.print("{s}------------- OPTIONAL\n", .{space});
+            onnx_log.debug("{s}------------- OPTIONAL\n", .{space});
             if (self.elem_type) |t| {
-                std.debug.print("{s}Element Type:\n", .{space});
+                onnx_log.debug("{s}Element Type:\n", .{space});
                 t.print(space);
             } else {
-                std.debug.print("{s}Element Type: (none)\n", .{space});
+                onnx_log.debug("{s}Element Type: (none)\n", .{space});
             }
         }
     };
@@ -388,7 +390,7 @@ pub const TypeProto = struct {
                     typeProto.optional_type = opt_ptr;
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for TypeProto", .{tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for TypeProto", .{tag});
                     try reader.skipField(tag.wire_type);
                 },
             }
@@ -402,47 +404,47 @@ pub const TypeProto = struct {
             return;
         };
 
-        std.debug.print("{s}------------- TYPE\n", .{space});
+        onnx_log.debug("{s}------------- TYPE\n", .{space});
 
         if (self.tensor_type) |t| {
-            std.debug.print("{s}Tensor Type:\n", .{space});
+            onnx_log.debug("{s}Tensor Type:\n", .{space});
             t.print(space);
         } else {
-            std.debug.print("{s}Tensor Type: (none)\n", .{space});
+            onnx_log.debug("{s}Tensor Type: (none)\n", .{space});
         }
 
         if (self.sequence_type) |s| {
-            std.debug.print("{s}Sequence Type:\n", .{space});
+            onnx_log.debug("{s}Sequence Type:\n", .{space});
             s.print(space);
         } else {
-            std.debug.print("{s}Sequence Type: (none)\n", .{space});
+            onnx_log.debug("{s}Sequence Type: (none)\n", .{space});
         }
 
         if (self.map_type) |m| {
-            std.debug.print("{s}Map Type:\n", .{space});
+            onnx_log.debug("{s}Map Type:\n", .{space});
             m.print(space);
         } else {
-            std.debug.print("{s}Map Type: (none)\n", .{space});
+            onnx_log.debug("{s}Map Type: (none)\n", .{space});
         }
 
         if (self.sparse_tensor_type) |st| {
-            std.debug.print("{s}Sparse Tensor Type:\n", .{space});
+            onnx_log.debug("{s}Sparse Tensor Type:\n", .{space});
             st.print(space);
         } else {
-            std.debug.print("{s}Sparse Tensor Type: (none)\n", .{space});
+            onnx_log.debug("{s}Sparse Tensor Type: (none)\n", .{space});
         }
 
         if (self.optional_type) |o| {
-            std.debug.print("{s}Optional Type:\n", .{space});
+            onnx_log.debug("{s}Optional Type:\n", .{space});
             o.print(space);
         } else {
-            std.debug.print("{s}Optional Type: (none)\n", .{space});
+            onnx_log.debug("{s}Optional Type: (none)\n", .{space});
         }
 
         if (self.denotation) |d| {
-            std.debug.print("{s}Denotation: {s}\n", .{ space, d });
+            onnx_log.debug("{s}Denotation: {s}\n", .{ space, d });
         } else {
-            std.debug.print("{s}Denotation: (none)\n", .{space});
+            onnx_log.debug("{s}Denotation: (none)\n", .{space});
         }
     }
 };

--- a/src/onnx/valueInfoProto.zig
+++ b/src/onnx/valueInfoProto.zig
@@ -6,6 +6,8 @@ const StringStringEntryProto = @import("onnx.zig").StringStringEntryProto;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 var printingAllocator = std.heap.ArenaAllocator.init(gpa.allocator());
 
+const onnx_log = std.log.scoped(.valueInfo);
+
 //https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L193
 //TAGS:
 //  - 1 : name, string
@@ -65,7 +67,7 @@ pub const ValueInfoProto = struct {
                     try metadataList.append(ssep_ptr);
                 },
                 else => {
-                    std.debug.print("\n\n ERROR: tag{} NOT AVAILABLE for ValueInfoProto", .{tag});
+                    onnx_log.warn("\n\n ERROR: tag{} NOT AVAILABLE for ValueInfoProto", .{tag});
                     return error.TagNotAvailable;
                 },
             }
@@ -79,28 +81,28 @@ pub const ValueInfoProto = struct {
         const space = std.mem.concat(printingAllocator.allocator(), u8, &[_][]const u8{ if (padding) |p| p else "", "   " }) catch {
             return;
         };
-        std.debug.print("{s}------------- VALUEINFO \n", .{space});
+        onnx_log.debug("{s}------------- VALUEINFO \n", .{space});
 
         if (self.name) |n| {
-            std.debug.print("{s}Name: {s}\n", .{ space, n });
+            onnx_log.debug("{s}Name: {s}\n", .{ space, n });
         } else {
-            std.debug.print("{s}Name: (none)\n", .{space});
+            onnx_log.debug("{s}Name: (none)\n", .{space});
         }
 
         if (self.type) |t| {
-            std.debug.print("{s}Type:\n", .{space});
+            onnx_log.debug("{s}Type:\n", .{space});
             t.print(space);
         } else {
-            std.debug.print("{s}Type: (none)\n", .{space});
+            onnx_log.debug("{s}Type: (none)\n", .{space});
         }
 
         if (self.doc_string) |doc| {
-            std.debug.print("{s}Doc: {s}\n", .{ space, doc });
+            onnx_log.debug("{s}Doc: {s}\n", .{ space, doc });
         } else {
-            std.debug.print("{s}Doc: (none)\n", .{space});
+            onnx_log.debug("{s}Doc: (none)\n", .{space});
         }
 
-        std.debug.print("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
+        onnx_log.debug("{s}metadata_props (key, value) [{}]: \n", .{ space, self.metadata_props.len });
         for (self.metadata_props) |mp| {
             mp.print(space);
         }

--- a/tests/CodeGen/oneOpModelGenerator.zig
+++ b/tests/CodeGen/oneOpModelGenerator.zig
@@ -9,13 +9,15 @@ const allocator = pkgAllocator.allocator;
 const onnx = zant.onnx;
 const codeGen = @import("codegen");
 
-pub fn main() !void {
-    std.debug.print("One ONNX Operator Model Generator", .{});
+const tests_log = std.log.scoped(.test_oneOP);
 
-    std.debug.print("\n     opening available_operations...", .{});
+pub fn main() !void {
+    tests_log.info("One ONNX Operator Model Generator", .{});
+
+    tests_log.info("\n     opening available_operations...", .{});
     const op_file = try std.fs.cwd().openFile("tests/CodeGen/Python-ONNX/available_operations.txt", .{});
     defer op_file.close();
-    std.debug.print(" done", .{});
+    tests_log.info(" done", .{});
 
     const file_size = try op_file.getEndPos();
     const buffer = try allocator.alloc(u8, @intCast(file_size));
@@ -53,8 +55,8 @@ pub fn main() !void {
         // Get the next line from the iterator.
         const maybe_line = lines_iter.next();
 
-        if (maybe_line) |ml| std.debug.print("maybe_line: {any}\n", .{ml}) else {
-            std.debug.print("maybe_line: null -----> break\n", .{});
+        if (maybe_line) |ml| tests_log.info("maybe_line: {any}\n", .{ml}) else {
+            tests_log.info("maybe_line: null -----> break\n", .{});
             break;
         }
 
@@ -62,13 +64,13 @@ pub fn main() !void {
         // Trim whitespace from the line.
         const trimmed_line = std.mem.trim(u8, raw_line, " \t\r\n");
         if (trimmed_line.len > 0) {
-            std.debug.print("Operation: {s}\n", .{trimmed_line});
+            tests_log.info("Operation: {s}\n", .{trimmed_line});
         }
 
         // Construct the model file path: "Phython-ONNX/{op}_0.onnx"
         const model_path = try std.fmt.allocPrint(allocator, "datasets/oneOpModels/{s}_0.onnx", .{trimmed_line});
         defer allocator.free(model_path);
-        std.debug.print("model_path : {s}", .{model_path});
+        tests_log.info("model_path : {s}", .{model_path});
 
         // Load the model.
         var model = try onnx.parseFromFile(allocator, model_path);
@@ -77,7 +79,7 @@ pub fn main() !void {
         //DEBUG
         model.print();
 
-        std.debug.print("\n CODEGENERATING {s} ...", .{model_path});
+        tests_log.info("\n CODEGENERATING {s} ...", .{model_path});
 
         // Create the generated model directory if not present
         const generated_path = try std.fmt.allocPrint(allocator, "generated/oneOpModels/{s}/", .{trimmed_line});
@@ -102,7 +104,7 @@ pub fn main() !void {
         defer allocator.free(generated_test_model_path);
 
         try codeGen.utils.copyFile(dataset_test_model_path, generated_test_model_path);
-        std.debug.print("Written user test for {s}", .{trimmed_line});
+        tests_log.info("Written user test for {s}", .{trimmed_line});
 
         // Add relative one op test to global tests file
         try test_oneop_writer.print("\t _ = @import(\"{s}/test_{s}.zig\"); \n", .{ trimmed_line, trimmed_line });

--- a/tests/CodeGen/test_model.slim.template.zig
+++ b/tests/CodeGen/test_model.slim.template.zig
@@ -6,12 +6,14 @@ const Tensor = zant.core.tensor.Tensor;
 const pkgAllocator = zant.utils.allocator;
 const allocator = pkgAllocator.allocator;
 
+const tests_log = std.log.scoped(.test_utils);
+
 const model = @import("model_options.zig");
 
 const ITERATION_COUNT: u32 = 100;
 
 test "Static Library - Random data Prediction Test" {
-    std.debug.print("\n     test: Static Library - Model: {s}  - Random data Prediction Test\n", .{model.name});
+    tests_log.info("\n     test: Static Library - Model: {s}  - Random data Prediction Test\n", .{model.name});
 
     var input_shape = model.input_shape;
 
@@ -46,11 +48,11 @@ test "Static Library - Random data Prediction Test" {
             &result,
         );
     }
-    std.debug.print("\nRan 100 fuzzy tests on model \"{s}\", done without errors:\n", .{model.name});
+    tests_log.info("\nRan 100 fuzzy tests on model \"{s}\", done without errors:\n", .{model.name});
 }
 
 test "Static Library - Inputs Prediction Test" {
-    std.debug.print("\n     test: Codegen one-op model: \"{s}\" compare with Pre-Generated results.\n", .{model.name});
+    tests_log.info("\n     test: Codegen one-op model: \"{s}\" compare with Pre-Generated results.\n", .{model.name});
 
     var input_shape = model.input_shape;
 
@@ -63,17 +65,17 @@ test "Static Library - Inputs Prediction Test" {
     const user_tests_path = try std.fmt.allocPrint(allocator, "generated/oneOpModels/{s}/user_tests.json", .{model.name});
     defer allocator.free(user_tests_path);
 
-    std.debug.print("{s}", .{user_tests_path});
+    tests_log.info("{s}", .{user_tests_path});
 
     const parsed_user_tests = try utils.loadUserTests(model.data_type, user_tests_path);
     defer parsed_user_tests.deinit();
 
     const user_tests = parsed_user_tests.value;
 
-    std.debug.print("\nUser tests loaded.\n", .{});
+    tests_log.info("\nUser tests loaded.\n", .{});
 
     for (user_tests) |user_test| {
-        std.debug.print("\n\tRunning user test: {s}\n\n", .{user_test.name});
+        tests_log.info("\n\tRunning user test: {s}\n\n", .{user_test.name});
 
         try std.testing.expectEqual(user_test.input.len, input_data_len);
 
@@ -91,9 +93,9 @@ test "Static Library - Inputs Prediction Test" {
             const result_value = result[i];
             const expected_output_value = expected_output;
             const approx_eq = std.math.approxEqAbs(model.data_type, expected_output_value, result_value, 0.001);
-            if(!approx_eq)
-                std.debug.print("Test failed for input: {d} expected: {} got: {}\n", .{ i, expected_output_value, result_value });
-            
+            if (!approx_eq)
+                tests_log.warn("Test failed for input: {d} expected: {} got: {}\n", .{ i, expected_output_value, result_value });
+
             try std.testing.expect(approx_eq);
         }
     }

--- a/tests/Core/Tensor/TensorMath/test_lib_elementWise_math.zig
+++ b/tests/Core/Tensor/TensorMath/test_lib_elementWise_math.zig
@@ -7,8 +7,9 @@ const Tensor = zant.core.tensor.Tensor;
 const TensorError = zant.utils.error_handler.TensorError;
 const TensorMathError = zant.utils.error_handler.TensorMathError;
 
+const tests_log = std.log.scoped(.lib_elementWise);
 test "Sum two tensors on CPU architecture" {
-    std.debug.print("\n     test: Sum two tensors on CPU architecture", .{});
+    tests_log.info("\n     test: Sum two tensors on CPU architecture", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray: [2][2]f32 = [_][2]f32{
@@ -32,7 +33,7 @@ test "Sum two tensors on CPU architecture" {
 }
 
 test "test tensor element-wise multiplication" {
-    std.debug.print("\n     test: tensor element-wise multiplication ", .{});
+    tests_log.info("\n     test: tensor element-wise multiplication ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Inizializzazione degli array di input
@@ -63,7 +64,7 @@ test "test tensor element-wise multiplication" {
 }
 
 test "Error when input tensors have different sizes" {
-    std.debug.print("\n     test: Error when input tensors have different sizes", .{});
+    tests_log.info("\n     test: Error when input tensors have different sizes", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray: [2][2]f32 = [_][2]f32{
@@ -87,7 +88,7 @@ test "Error when input tensors have different sizes" {
 }
 
 test "add bias" {
-    std.debug.print("\n     test:add bias", .{});
+    tests_log.info("\n     test:add bias", .{});
     const allocator = pkgAllocator.allocator;
 
     var shape_tensor: [2]usize = [_]usize{ 2, 3 }; // 2x3 matrix
@@ -114,7 +115,7 @@ test "add bias" {
 }
 
 test "Subtraction with same shape tensors" {
-    std.debug.print("\n     test: Subtraction with same shape tensors", .{});
+    tests_log.info("\n     test: Subtraction with same shape tensors", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray1: [2][2]f32 = [_][2]f32{
@@ -144,7 +145,7 @@ test "Subtraction with same shape tensors" {
 }
 
 test "Subtraction with broadcasting - scalar and matrix" {
-    std.debug.print("\n     test: Subtraction with broadcasting - scalar and matrix", .{});
+    tests_log.info("\n     test: Subtraction with broadcasting - scalar and matrix", .{});
     const allocator = pkgAllocator.allocator;
 
     // Matrix 2x2
@@ -173,7 +174,7 @@ test "Subtraction with broadcasting - scalar and matrix" {
 }
 
 test "Subtraction with broadcasting - row and matrix" {
-    std.debug.print("\n     test: Subtraction with broadcasting - row and matrix", .{});
+    tests_log.info("\n     test: Subtraction with broadcasting - row and matrix", .{});
     const allocator = pkgAllocator.allocator;
 
     // Matrix 2x2
@@ -204,7 +205,7 @@ test "Subtraction with broadcasting - row and matrix" {
 }
 
 test "Subtraction with incompatible shapes" {
-    std.debug.print("\n     test: Subtraction with incompatible shapes", .{});
+    tests_log.info("\n     test: Subtraction with incompatible shapes", .{});
     const allocator = pkgAllocator.allocator;
 
     // Matrix 2x2
@@ -231,7 +232,7 @@ test "Subtraction with incompatible shapes" {
 }
 
 test "Lean subtraction with SIMD optimization" {
-    std.debug.print("\n     test: Lean subtraction with SIMD optimization", .{});
+    tests_log.info("\n     test: Lean subtraction with SIMD optimization", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create larger tensors to test SIMD optimization
@@ -275,7 +276,7 @@ test "Lean subtraction with SIMD optimization" {
 }
 
 test "test tensor element-wise division" {
-    std.debug.print("\n     test: tensor element-wise division ", .{});
+    tests_log.info("\n     test: tensor element-wise division ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Inizializzazione degli array di input
@@ -306,7 +307,7 @@ test "test tensor element-wise division" {
 }
 
 test "Sum list of tensors - normal case" {
-    std.debug.print("\n     test: Sum list of tensors - normal case", .{});
+    tests_log.info("\n     test: Sum list of tensors - normal case", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray1: [2][2]f32 = [_][2]f32{
@@ -342,7 +343,7 @@ test "Sum list of tensors - normal case" {
 }
 
 test "Sum list of tensors - single tensor case" {
-    std.debug.print("\n     test: Sum list of tensors - single tensor case", .{});
+    tests_log.info("\n     test: Sum list of tensors - single tensor case", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray: [2][2]f32 = [_][2]f32{
@@ -365,14 +366,14 @@ test "Sum list of tensors - single tensor case" {
 }
 
 test "Sum list of tensors - empty list error" {
-    std.debug.print("\n     test: Sum list of tensors - empty list error", .{});
+    tests_log.info("\n     test: Sum list of tensors - empty list error", .{});
 
     var tensors = [_]*Tensor(f32){};
     try std.testing.expectError(TensorMathError.EmptyTensorList, TensMath.sum_tensor_list(f32, f32, &tensors));
 }
 
 test "Sum list of tensors - different sizes error" {
-    std.debug.print("\n     test: Sum list of tensors - different sizes error", .{});
+    tests_log.info("\n     test: Sum list of tensors - different sizes error", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray1: [2][2]f32 = [_][2]f32{
@@ -398,7 +399,7 @@ test "Sum list of tensors - different sizes error" {
 }
 
 test "Sum list of tensors - type promotion" {
-    std.debug.print("\n     test: Sum list of tensors - type promotion", .{});
+    tests_log.info("\n     test: Sum list of tensors - type promotion", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray1: [2][2]u8 = [_][2]u8{
@@ -428,7 +429,7 @@ test "Sum list of tensors - type promotion" {
 }
 
 test "test tensor element-wise tanh with valid f32 tensor" {
-    std.debug.print("\n     test: tensor element-wise tanh with valid f32 tensor", .{});
+    tests_log.info("\n     test: tensor element-wise tanh with valid f32 tensor", .{});
     const allocator = std.testing.allocator;
 
     var inputArray: [2][3]f32 = [_][3]f32{
@@ -452,7 +453,7 @@ test "test tensor element-wise tanh with valid f32 tensor" {
 }
 
 test "test tensor element-wise ceil with valid f32 tensor" {
-    std.debug.print("\n     test: tensor element-wise ceil with valid f32 tensor", .{});
+    tests_log.info("\n     test: tensor element-wise ceil with valid f32 tensor", .{});
     const allocator = std.testing.allocator;
 
     var inputArray: [2][3]f32 = [_][3]f32{
@@ -476,7 +477,7 @@ test "test tensor element-wise ceil with valid f32 tensor" {
 }
 
 test "clip f32 basic" {
-    std.debug.print("\n     test: clip f32 basic", .{});
+    tests_log.info("\n     test: clip f32 basic", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{5};
     var input = try Tensor(f32).fromArray(&allocator, &[_]f32{ -5.0, 0.0, 5.0, 10.0, 15.0 }, &shape);
@@ -500,7 +501,7 @@ test "clip f32 basic" {
 }
 
 test "clip i32 with defaults" {
-    std.debug.print("\n     test: clip i32 with defaults", .{});
+    tests_log.info("\n     test: clip i32 with defaults", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{4};
     var input = try Tensor(i32).fromArray(&allocator, &[_]i32{ -100, 0, 100, 200 }, &shape);
@@ -515,7 +516,7 @@ test "clip i32 with defaults" {
 }
 
 test "clip f32 min only" {
-    std.debug.print("\n     test: clip f32 min only", .{});
+    tests_log.info("\n     test: clip f32 min only", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{4};
     var input = try Tensor(f32).fromArray(&allocator, &[_]f32{ -5.0, -1.0, 0.0, 5.0 }, &shape);
@@ -534,7 +535,7 @@ test "clip f32 min only" {
 }
 
 test "clip f32 max only" {
-    std.debug.print("\n     test: clip f32 max only", .{});
+    tests_log.info("\n     test: clip f32 max only", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{4};
     var input = try Tensor(f32).fromArray(&allocator, &[_]f32{ -5.0, 0.0, 5.0, 15.0 }, &shape);
@@ -553,7 +554,7 @@ test "clip f32 max only" {
 }
 
 test "clip f32 min > max" {
-    std.debug.print("\n     test: clip f32 min > max", .{});
+    tests_log.info("\n     test: clip f32 min > max", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{4};
     var input = try Tensor(f32).fromArray(&allocator, &[_]f32{ -5.0, 0.0, 5.0, 10.0 }, &shape);
@@ -576,7 +577,7 @@ test "clip f32 min > max" {
 }
 
 test "clip error: min not scalar" {
-    std.debug.print("\n     test: clip error: min not scalar", .{});
+    tests_log.info("\n     test: clip error: min not scalar", .{});
     const allocator = pkgAllocator.allocator;
     var shape1 = [_]usize{1};
     var input = try Tensor(f32).fromArray(&allocator, &[_]f32{1.0}, &shape1);
@@ -590,7 +591,7 @@ test "clip error: min not scalar" {
 }
 
 test "clip error: max not scalar" {
-    std.debug.print("\n     test: clip error: max not scalar", .{});
+    tests_log.info("\n     test: clip error: max not scalar", .{});
     const allocator = pkgAllocator.allocator;
     var shape1 = [_]usize{1};
     var input = try Tensor(f32).fromArray(&allocator, &[_]f32{1.0}, &shape1);
@@ -604,7 +605,7 @@ test "clip error: max not scalar" {
 }
 
 test "clip empty input" {
-    std.debug.print("\n     test: clip empty input", .{});
+    tests_log.info("\n     test: clip empty input", .{});
     const allocator = pkgAllocator.allocator;
     var input = try Tensor(f32).init(&allocator);
     // No need to deinit empty tensor if init doesn't allocate
@@ -614,7 +615,7 @@ test "clip empty input" {
 }
 
 test "clip with SIMD vector size 1" {
-    std.debug.print("\n     test: clip with SIMD vector size 1", .{});
+    tests_log.info("\n     test: clip with SIMD vector size 1", .{});
     // Test case for types where SIMD might not be beneficial or available
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{6};
@@ -637,7 +638,7 @@ test "clip with SIMD vector size 1" {
 }
 
 test "clip f32 large tensor with SIMD" {
-    std.debug.print("\n     test: clip f32 large tensor with SIMD", .{});
+    tests_log.info("\n     test: clip f32 large tensor with SIMD", .{});
     const allocator = pkgAllocator.allocator;
     const size = 1024;
     var input_data = try allocator.alloc(f32, size);

--- a/tests/Core/Tensor/TensorMath/test_lib_logical_math.zig
+++ b/tests/Core/Tensor/TensorMath/test_lib_logical_math.zig
@@ -6,8 +6,10 @@ const TensMath = zant.core.tensor.math_standard;
 const Tensor = zant.core.tensor.Tensor;
 const TensorError = zant.utils.error_handler.TensorError;
 
+const tests_log = std.log.scoped(.test_lib_logical_math);
+
 test "equal() " {
-    std.debug.print("\n     test:equal()", .{});
+    tests_log.info("\n     test:equal()", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray: [2][2]f32 = [_][2]f32{
@@ -48,7 +50,7 @@ test "equal() " {
 }
 
 test "tests isSafe() method" {
-    std.debug.print("\n     test: isSafe() method ", .{});
+    tests_log.info("\n     test: isSafe() method ", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -66,7 +68,7 @@ test "tests isSafe() method" {
 }
 
 test "tests isSafe() -> TensorError.NotFiniteValue " {
-    std.debug.print("\n     test: isSafe()-> TensorError.NotFiniteValue", .{});
+    tests_log.info("\n     test: isSafe()-> TensorError.NotFiniteValue", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -87,7 +89,7 @@ test "tests isSafe() -> TensorError.NotFiniteValue " {
 }
 
 test "tests isSafe() -> TensorError.NanValue " {
-    std.debug.print("\n     test: isSafe()-> TensorError.NanValue", .{});
+    tests_log.info("\n     test: isSafe()-> TensorError.NanValue", .{});
 
     const allocator = pkgAllocator.allocator;
 

--- a/tests/Core/Tensor/TensorMath/test_lib_reduction_math.zig
+++ b/tests/Core/Tensor/TensorMath/test_lib_reduction_math.zig
@@ -4,8 +4,10 @@ const pkgAllocator = zant.utils.allocator;
 const TensMath = zant.core.tensor.math_standard;
 const Tensor = zant.core.tensor.Tensor;
 
+const tests_log = std.log.scoped(.test_lib_reduction);
+
 test "mean" {
-    std.debug.print("\n     test:mean", .{});
+    tests_log.info("\n     test:mean", .{});
     const allocator = pkgAllocator.allocator;
 
     var shape_tensor: [1]usize = [_]usize{3}; // 2x3 matrix
@@ -19,7 +21,7 @@ test "mean" {
 }
 
 test "reduce_mean" {
-    std.debug.print("\n     test:reduce_mean", .{});
+    tests_log.info("\n     test:reduce_mean", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test case 1: 2D tensor, reduce along axis 0
@@ -120,7 +122,7 @@ test "reduce_mean" {
 }
 
 test "reduce_mean_advanced" {
-    std.debug.print("\n     test:reduce_mean_advanced", .{});
+    tests_log.info("\n     test:reduce_mean_advanced", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test case 1: 3D tensor with non-contiguous axes

--- a/tests/Core/Tensor/TensorMath/test_lib_shape_math.zig
+++ b/tests/Core/Tensor/TensorMath/test_lib_shape_math.zig
@@ -6,8 +6,10 @@ const Tensor = zant.core.tensor.Tensor;
 const TensorError = zant.utils.error_handler.TensorError;
 const TensorMathError = zant.utils.error_handler.TensorMathError;
 
+const tests_log = std.log.scoped(.test_lib_shape);
+
 test "Concatenate tensors along axis 0" {
-    std.debug.print("\n     test: Concatenate tensors along axis 0", .{});
+    tests_log.info("\n     test: Concatenate tensors along axis 0", .{});
     var allocator = pkgAllocator.allocator;
 
     var inputArray1: [2][2]f32 = [_][2]f32{
@@ -44,14 +46,14 @@ test "Concatenate tensors along axis 0" {
 
     for (0..4) |i| {
         for (0..2) |j| {
-            //std.debug.print("Checking result_tensor[{d}][{d}]: {f}\n", .{ i, j, result_tensor.data[i * 2 + j] });
+            //tests_log.debug("Checking result_tensor[{d}][{d}]: {f}\n", .{ i, j, result_tensor.data[i * 2 + j] });
             try std.testing.expect(result_tensor.data[i * 2 + j] == expected_data[i][j]);
         }
     }
 }
 
 test "Concatenate tensors along axis 1" {
-    std.debug.print("\n     test: Concatenate tensors along axis 1", .{});
+    tests_log.info("\n     test: Concatenate tensors along axis 1", .{});
     var allocator = pkgAllocator.allocator;
 
     var inputArray1: [2][2]f32 = [_][2]f32{
@@ -87,14 +89,14 @@ test "Concatenate tensors along axis 1" {
 
     for (0..2) |i| {
         for (0..4) |j| {
-            //std.debug.print("Checking result_tensor[{d}][{d}]: {f}\n", .{ i, j, result_tensor.data[i * 4 + j] });
+            //tests_log.info("Checking result_tensor[{d}][{d}]: {f}\n", .{ i, j, result_tensor.data[i * 4 + j] });
             try std.testing.expect(result_tensor.data[i * 4 + j] == expected_data[i][j]);
         }
     }
 }
 
 test "Concatenate tensors along negative axis" {
-    std.debug.print("\n     test: Concatenate tensors along negative axis", .{});
+    tests_log.info("\n     test: Concatenate tensors along negative axis", .{});
     var allocator = std.testing.allocator;
 
     var inputArray1: [2][2]f32 = [_][2]f32{
@@ -137,7 +139,7 @@ test "Concatenate tensors along negative axis" {
 }
 
 test "Concatenate 3D tensors along axis 2" {
-    std.debug.print("\n     test: Concatenate 3D tensors along axis 2", .{});
+    tests_log.info("\n     test: Concatenate 3D tensors along axis 2", .{});
     var allocator = std.testing.allocator;
 
     // Tensor A: shape [2, 2, 2]
@@ -189,7 +191,7 @@ test "Concatenate 3D tensors along axis 2" {
 }
 
 test "transpose" {
-    std.debug.print("\n     test: transpose ", .{});
+    tests_log.info("\n     test: transpose ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Inizializzazione degli array di input
@@ -214,7 +216,7 @@ test "transpose" {
 }
 
 test "transpose multi-dimensions default" {
-    std.debug.print("\n     test: transpose multi-dimensions ", .{});
+    tests_log.info("\n     test: transpose multi-dimensions ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Initialize input Array and shape
@@ -245,7 +247,7 @@ test "transpose multi-dimensions default" {
 }
 
 test "test addPaddingAndDilation() " {
-    std.debug.print("\n     test: addPadding()", .{});
+    tests_log.info("\n     test: addPadding()", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -305,7 +307,7 @@ test "test addPaddingAndDilation() " {
 }
 
 test "test addPaddingAndDilation() -> zero dilatation " {
-    std.debug.print("\n     test: addPadding() -> zero dilatation ", .{});
+    tests_log.info("\n     test: addPadding() -> zero dilatation ", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -361,7 +363,7 @@ test "test addPaddingAndDilation() -> zero dilatation " {
 }
 
 test "test addPaddingAndDilation() -> zero padding" {
-    std.debug.print("\n     test: addPaddingAndDilation() -> zero padding", .{});
+    tests_log.info("\n     test: addPaddingAndDilation() -> zero padding", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -422,7 +424,7 @@ test "test addPaddingAndDilation() -> zero padding" {
 }
 
 test "test neg() " {
-    std.debug.print("\n     test: neg()", .{});
+    tests_log.info("\n     test: neg()", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -462,7 +464,7 @@ test "test neg() " {
     var resultShape: [3]usize = [_]usize{ 2, 3, 3 };
     var resultTensor = try Tensor(i8).fromArray(&allocator, &resultArray, &resultShape);
     defer resultTensor.deinit();
-    std.debug.print("TRY WITH THISSS: \n", .{});
+    tests_log.debug("TRY WITH THISSS: \n", .{});
     resultTensor.printMultidim();
 
     //check on data
@@ -478,7 +480,7 @@ test "test neg() " {
 }
 
 test "resize with nearest neighbor interpolation" {
-    std.debug.print("\n     test: resize with nearest neighbor interpolation", .{});
+    tests_log.info("\n     test: resize with nearest neighbor interpolation", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test 1D tensor resize
@@ -518,7 +520,7 @@ test "resize with nearest neighbor interpolation" {
 }
 
 test "resize with linear interpolation" {
-    std.debug.print("\n     test: resize with linear interpolation", .{});
+    tests_log.info("\n     test: resize with linear interpolation", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test 1D tensor resize
@@ -554,7 +556,7 @@ test "resize with linear interpolation" {
 }
 
 test "resize with cubic interpolation" {
-    std.debug.print("\n     test: resize with cubic interpolation", .{});
+    tests_log.info("\n     test: resize with cubic interpolation", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test 1D tensor resize
@@ -572,7 +574,7 @@ test "resize with cubic interpolation" {
 }
 
 test "resize with explicit sizes" {
-    std.debug.print("\n     test: resize with explicit sizes", .{});
+    tests_log.info("\n     test: resize with explicit sizes", .{});
     const allocator = pkgAllocator.allocator;
 
     var input_array = [_][2]u8{
@@ -594,7 +596,7 @@ test "resize with explicit sizes" {
 }
 
 test "resize error cases" {
-    std.debug.print("\n     test: resize error cases", .{});
+    tests_log.info("\n     test: resize error cases", .{});
     const allocator = pkgAllocator.allocator;
 
     var input_array = [_][2]u8{
@@ -627,7 +629,7 @@ test "resize error cases" {
 }
 
 test "split basic test" {
-    std.debug.print("\n     test: split basic test", .{});
+    tests_log.info("\n     test: split basic test", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -656,7 +658,7 @@ test "split basic test" {
 }
 
 test "split with custom sizes" {
-    std.debug.print("\n     test: split with custom sizes", .{});
+    tests_log.info("\n     test: split with custom sizes", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 4x2 tensor
@@ -696,7 +698,7 @@ test "split with custom sizes" {
 }
 
 test "split with negative axis" {
-    std.debug.print("\n     test: split with negative axis", .{});
+    tests_log.info("\n     test: split with negative axis", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x4 tensor
@@ -740,7 +742,7 @@ test "split with negative axis" {
 }
 
 test "get_resize_output_shape()" {
-    std.debug.print("\n     test: get_resize_output_shape \n", .{});
+    tests_log.info("\n     test: get_resize_output_shape \n", .{});
 
     var input_shape = [_]usize{ 2, 3, 4 };
     var scales = [_]f32{ 2.0, 1.5, 0.5 };
@@ -779,7 +781,7 @@ test "get_resize_output_shape()" {
 }
 
 test "get_concatenate_output_shape" {
-    std.debug.print("\n     test: get_concatenate_output_shape \n", .{});
+    tests_log.info("\n     test: get_concatenate_output_shape \n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -836,7 +838,7 @@ test "get_concatenate_output_shape" {
 }
 
 test "get_split_output_shapes()" {
-    std.debug.print("\n     test: get_split_output_shapes \n", .{});
+    tests_log.info("\n     test: get_split_output_shapes \n", .{});
 
     const allocator = pkgAllocator.allocator;
     var input_shape = [_]usize{ 2, 3, 4 };
@@ -887,13 +889,13 @@ test "get_split_output_shapes()" {
 }
 
 test "Empty tensor list error" {
-    std.debug.print("\n     test: Empty tensor list error", .{});
+    tests_log.info("\n     test: Empty tensor list error", .{});
     const empty_shapes: []const []const usize = &[_][]const usize{};
     try std.testing.expectError(TensorMathError.EmptyTensorList, TensMath.get_concatenate_output_shape(empty_shapes, 0));
 }
 
 test "Reshape" {
-    std.debug.print("\n     test: Reshape ", .{});
+    tests_log.info("\n     test: Reshape ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Inizializzazione degli array di input
@@ -910,7 +912,7 @@ test "Reshape" {
     var new_tens = try TensMath.reshape(u8, &tensor, &new_shape, false);
     defer new_tens.deinit();
 
-    std.debug.print(" \n\n  new_tens.shape= {any} ", .{new_tens.shape});
+    tests_log.debug(" \n\n  new_tens.shape= {any} ", .{new_tens.shape});
 
     try std.testing.expect(new_tens.size == new_tens.size);
     try std.testing.expect(new_tens.shape[2] == 3);
@@ -923,7 +925,7 @@ test "gather along axis 0 and axis 1" {
     // -------------------------------------------------------------------------------------
     // Test Case 1: Gather Along Axis 0
     // -------------------------------------------------------------------------------------
-    std.debug.print("\n     test: gather along axis 0", .{});
+    tests_log.info("\n     test: gather along axis 0", .{});
 
     // Initialize input tensor: 3x3 matrix
     var inputArray0: [3][3]u8 = [_][3]u8{
@@ -964,7 +966,7 @@ test "gather along axis 0 and axis 1" {
     // -------------------------------------------------------------------------------------
     // Test Case 2: Gather Along Axis 1
     // -------------------------------------------------------------------------------------
-    std.debug.print("\n     test: gather along axis 1", .{});
+    tests_log.info("\n     test: gather along axis 1", .{});
 
     var inputArray1: [2][4]u8 = [_][4]u8{
         [_]u8{ 10, 20, 30, 40 },
@@ -1002,27 +1004,27 @@ test "gather along axis 0 and axis 1" {
     }
 
     // Check data
-    std.debug.print("\n     gatheredTensor1.size: {}\n", .{gatheredTensor1.size});
+    tests_log.debug("\n     gatheredTensor1.size: {}\n", .{gatheredTensor1.size});
     gatheredTensor1.print();
 
     try std.testing.expect(gatheredTensor1.size == 8);
     for (0..gatheredTensor1.size) |i| {
-        std.debug.print("\n     gatheredTensor1.data[i]: {}\n", .{expectedData1[i]});
-        std.debug.print("\n     expectedData1[i]: {}\n", .{gatheredTensor1.data[i]});
+        tests_log.debug("\n     gatheredTensor1.data[i]: {}\n", .{expectedData1[i]});
+        tests_log.debug("\n     expectedData1[i]: {}\n", .{gatheredTensor1.data[i]});
         try std.testing.expect(gatheredTensor1.data[i] == expectedData1[i]);
     }
 
     // -------------------------------------------------------------------------------------
     // Test Case 3: Error Handling - Invalid Axis
     // -------------------------------------------------------------------------------------
-    std.debug.print("\n     test: gather with invalid axis", .{});
+    tests_log.info("\n     test: gather with invalid axis", .{});
     const invalidAxis: usize = 3; // Input tensor has 2 dimensions
     const result0 = TensMath.gather(u8, &inputTensor0, &indicesTensor0, invalidAxis);
     try std.testing.expect(result0 == TensorError.InvalidAxis);
 }
 
 test "get_slice_output_shape basic slicing" {
-    std.debug.print("\n     test: get_slice_output_shape basic slicing", .{});
+    tests_log.info("\n     test: get_slice_output_shape basic slicing", .{});
     const allocator = pkgAllocator.allocator;
 
     var input_shape = [_]usize{ 5, 5, 5 };
@@ -1067,7 +1069,7 @@ test "get_slice_output_shape basic slicing" {
 }
 
 test "get_slice_output_shape with axes and negative steps" {
-    std.debug.print("\n     test: get_slice_output_shape with axes and negative steps", .{});
+    tests_log.info("\n     test: get_slice_output_shape with axes and negative steps", .{});
     const allocator = pkgAllocator.allocator;
 
     var input_shape = [_]usize{ 5, 5, 5 };
@@ -1081,11 +1083,11 @@ test "get_slice_output_shape with axes and negative steps" {
         const output_shape = try TensMath.get_slice_output_shape(&input_shape, &starts, &ends, &axes, null);
         defer allocator.free(output_shape);
 
-        std.debug.print("\n     Specific axes test - output shape: ", .{});
+        tests_log.debug("\n     Specific axes test - output shape: ", .{});
         for (output_shape) |dim| {
-            std.debug.print("{} ", .{dim});
+            tests_log.debug("{} ", .{dim});
         }
-        std.debug.print("\n", .{});
+        tests_log.debug("\n", .{});
 
         try std.testing.expectEqual(@as(usize, 3), output_shape.len);
         try std.testing.expectEqual(@as(usize, 5), output_shape[0]); // unchanged
@@ -1099,19 +1101,19 @@ test "get_slice_output_shape with axes and negative steps" {
         var ends = [_]i64{ 1, 1, 1 };
         var steps = [_]i64{ -1, -1, -1 };
 
-        std.debug.print("\n     Negative steps test - inputs:", .{});
-        std.debug.print("\n     starts: {} {} {}", .{ starts[0], starts[1], starts[2] });
-        std.debug.print("\n     ends: {} {} {}", .{ ends[0], ends[1], ends[2] });
-        std.debug.print("\n     steps: {} {} {}", .{ steps[0], steps[1], steps[2] });
+        tests_log.debug("\n     Negative steps test - inputs:", .{});
+        tests_log.debug("\n     starts: {} {} {}", .{ starts[0], starts[1], starts[2] });
+        tests_log.debug("\n     ends: {} {} {}", .{ ends[0], ends[1], ends[2] });
+        tests_log.debug("\n     steps: {} {} {}", .{ steps[0], steps[1], steps[2] });
 
         const output_shape = try TensMath.get_slice_output_shape(&input_shape, &starts, &ends, null, &steps);
         defer allocator.free(output_shape);
 
-        std.debug.print("\n     Negative steps test - output shape: ", .{});
+        tests_log.debug("\n     Negative steps test - output shape: ", .{});
         for (output_shape) |dim| {
-            std.debug.print("{} ", .{dim});
+            tests_log.debug("{} ", .{dim});
         }
-        std.debug.print("\n", .{});
+        tests_log.debug("\n", .{});
 
         try std.testing.expectEqual(@as(usize, 3), output_shape.len);
         // For negative steps, we expect:
@@ -1124,7 +1126,7 @@ test "get_slice_output_shape with axes and negative steps" {
 }
 
 test "get_slice_output_shape error cases" {
-    std.debug.print("\n     test: get_slice_output_shape error cases", .{});
+    tests_log.info("\n     test: get_slice_output_shape error cases", .{});
 
     var input_shape = [_]usize{ 5, 5, 5 };
 
@@ -1161,7 +1163,7 @@ test "get_slice_output_shape error cases" {
 }
 
 test "transpose_onnx basic operations" {
-    std.debug.print("\n     test: transpose_onnx basic operations", .{});
+    tests_log.info("\n     test: transpose_onnx basic operations", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test Case 1: Basic 2D transpose without perm
@@ -1271,7 +1273,7 @@ test "transpose_onnx basic operations" {
 }
 
 test "get_transpose_output_shape basic operations" {
-    std.debug.print("\n     test: get_transpose_output_shape basic operations", .{});
+    tests_log.info("\n     test: get_transpose_output_shape basic operations", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test Case 1: Basic 2D shape without perm
@@ -1408,7 +1410,7 @@ test "shape_onnx basic operations" {
 }
 
 test "lean_shape_onnx basic operations" {
-    std.debug.print("\n     test: lean_shape_onnx basic operations", .{});
+    tests_log.info("\n     test: lean_shape_onnx basic operations", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test Case 1: Basic operation with pre-allocated output tensor
@@ -1583,7 +1585,7 @@ test "get_shape_output_shape" {
 
 // f23 input tensor with [2, 3] shape and axes = [1] => expected output: [2, 1, 3]
 test "test unsqueeze valid" {
-    std.debug.print("\n     test: unsqueeze valid\n", .{});
+    tests_log.info("\n     test: unsqueeze valid\n", .{});
     const allocator = std.testing.allocator;
 
     // Input tensor
@@ -1620,7 +1622,7 @@ test "test unsqueeze valid" {
 // -------------------------------------------------------------
 // Test for AxisOutOfBounds error
 test "test unsqueeze axis out of bounds error" {
-    std.debug.print("\n test: unsqueeze axis out of bounds error\n", .{});
+    tests_log.info("\n test: unsqueeze axis out of bounds error\n", .{});
     const allocator = std.testing.allocator;
 
     var inputArray: [2][3]f32 = [_][3]f32{
@@ -1644,7 +1646,7 @@ test "test unsqueeze axis out of bounds error" {
 // -------------------------------------------------------------
 // Test for DuplicateAxis error
 test "test unsqueeze duplicate axis error" {
-    std.debug.print("\n test: unsqueeze duplicate axis error\n", .{});
+    tests_log.info("\n test: unsqueeze duplicate axis error\n", .{});
     const allocator = std.testing.allocator;
 
     var inputArray: [2][3]f32 = [_][3]f32{
@@ -1666,7 +1668,7 @@ test "test unsqueeze duplicate axis error" {
 }
 
 test "Reshape - Basic" {
-    std.debug.print("\n     test: Reshape - Basic ", .{});
+    tests_log.info("\n     test: Reshape - Basic ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -1699,7 +1701,7 @@ test "Reshape - Basic" {
 }
 
 test "Reshape - Multi-dimensional" {
-    std.debug.print("\n     test: Reshape - Multi-dimensional ", .{});
+    tests_log.info("\n     test: Reshape - Multi-dimensional ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x2x2 tensor
@@ -1735,7 +1737,7 @@ test "Reshape - Multi-dimensional" {
 }
 
 test "Reshape - Error case" {
-    std.debug.print("\n     test: Reshape - Error case ", .{});
+    tests_log.info("\n     test: Reshape - Error case ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -1754,7 +1756,7 @@ test "Reshape - Error case" {
 }
 
 test "Reshape - Same size different dimensions" {
-    std.debug.print("\n     test: Reshape - Same size different dimensions ", .{});
+    tests_log.info("\n     test: Reshape - Same size different dimensions ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -1784,7 +1786,7 @@ test "Reshape - Same size different dimensions" {
 }
 
 test "Reshape - With negative dimension" {
-    std.debug.print("\n     test: Reshape - With negative dimension ", .{});
+    tests_log.info("\n     test: Reshape - With negative dimension ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -1814,7 +1816,7 @@ test "Reshape - With negative dimension" {
 }
 
 test "Reshape - With zero dimension" {
-    std.debug.print("\n     test: Reshape - With zero dimension ", .{});
+    tests_log.info("\n     test: Reshape - With zero dimension ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -1844,7 +1846,7 @@ test "Reshape - With zero dimension" {
 }
 
 test "Reshape - Multiple negative dimensions (should fail)" {
-    std.debug.print("\n     test: Reshape - Multiple negative dimensions ", .{});
+    tests_log.info("\n     test: Reshape - Multiple negative dimensions ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -1863,7 +1865,7 @@ test "Reshape - Multiple negative dimensions (should fail)" {
 }
 
 test "gather - negative axis" {
-    std.debug.print("\n     test: gather - negative axis", .{});
+    tests_log.info("\n     test: gather - negative axis", .{});
     const allocator = pkgAllocator.allocator;
 
     // Initialize input tensor: 2x3 matrix
@@ -1894,7 +1896,7 @@ test "gather - negative axis" {
 }
 
 test "gather - invalid indices" {
-    std.debug.print("\n     test: gather - invalid indices", .{});
+    tests_log.info("\n     test: gather - invalid indices", .{});
     const allocator = pkgAllocator.allocator;
 
     // Initialize input tensor: 2x2 matrix
@@ -1917,7 +1919,7 @@ test "gather - invalid indices" {
 }
 
 test "gather - multi-dimensional indices" {
-    std.debug.print("\n     test: gather - multi-dimensional indices", .{});
+    tests_log.info("\n     test: gather - multi-dimensional indices", .{});
     const allocator = pkgAllocator.allocator;
 
     // Initialize input tensor: 3x3 matrix
@@ -1966,7 +1968,7 @@ test "gather - multi-dimensional indices" {
 }
 
 test "gather - single element tensor" {
-    std.debug.print("\n     test: gather - single element tensor", .{});
+    tests_log.info("\n     test: gather - single element tensor", .{});
     const allocator = pkgAllocator.allocator;
 
     // Initialize input tensor: [[[1]]]
@@ -1992,7 +1994,7 @@ test "gather - single element tensor" {
 }
 
 test "unsqueeze - basic" {
-    std.debug.print("\n     test: unsqueeze - basic", .{});
+    tests_log.info("\n     test: unsqueeze - basic", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -2026,7 +2028,7 @@ test "unsqueeze - basic" {
 }
 
 test "unsqueeze - multiple axes" {
-    std.debug.print("\n     test: unsqueeze - multiple axes", .{});
+    tests_log.info("\n     test: unsqueeze - multiple axes", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x2 tensor
@@ -2061,7 +2063,7 @@ test "unsqueeze - multiple axes" {
 }
 
 test "unsqueeze - negative axes" {
-    std.debug.print("\n     test: unsqueeze - negative axes", .{});
+    tests_log.info("\n     test: unsqueeze - negative axes", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -2095,7 +2097,7 @@ test "unsqueeze - negative axes" {
 }
 
 test "unsqueeze - scalar tensor" {
-    std.debug.print("\n     test: unsqueeze - scalar tensor", .{});
+    tests_log.info("\n     test: unsqueeze - scalar tensor", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 1x1 tensor
@@ -2124,7 +2126,7 @@ test "unsqueeze - scalar tensor" {
 }
 
 test "unsqueeze - error cases" {
-    std.debug.print("\n     test: unsqueeze - error cases", .{});
+    tests_log.info("\n     test: unsqueeze - error cases", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x2 tensor
@@ -2158,7 +2160,7 @@ test "unsqueeze - error cases" {
 }
 
 test "Concatenate tensors with mismatched shapes" {
-    std.debug.print("\n     test: Concatenate tensors with mismatched shapes", .{});
+    tests_log.info("\n     test: Concatenate tensors with mismatched shapes", .{});
     var allocator = pkgAllocator.allocator;
 
     var inputArray1: [2][2]f32 = [_][2]f32{
@@ -2204,7 +2206,7 @@ test "Concatenate tensors with mismatched shapes" {
 }
 
 test "Concatenate tensors with invalid axis" {
-    std.debug.print("\n     test: Concatenate tensors with invalid axis", .{});
+    tests_log.info("\n     test: Concatenate tensors with invalid axis", .{});
     var allocator = pkgAllocator.allocator;
 
     var inputArray1: [2][2]f32 = [_][2]f32{
@@ -2232,7 +2234,7 @@ test "Concatenate tensors with invalid axis" {
 }
 
 test "get_concatenate_output_shape - 3D tensors" {
-    std.debug.print("\n     test: get_concatenate_output_shape - 3D tensors", .{});
+    tests_log.info("\n     test: get_concatenate_output_shape - 3D tensors", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test shapes for 3D tensors
@@ -2270,7 +2272,7 @@ test "get_concatenate_output_shape - 3D tensors" {
 }
 
 test "get_concatenate_output_shape - mismatched shapes" {
-    std.debug.print("\n     test: get_concatenate_output_shape - mismatched shapes", .{});
+    tests_log.info("\n     test: get_concatenate_output_shape - mismatched shapes", .{});
 
     // Test shapes with mismatched dimensions
     var shapes = [_][]const usize{
@@ -2295,7 +2297,7 @@ test "get_concatenate_output_shape - mismatched shapes" {
 //Mismatched rank now supported
 
 test "get_concatenate_output_shape - invalid axis" {
-    std.debug.print("\n     test: get_concatenate_output_shape - invalid axis", .{});
+    tests_log.info("\n     test: get_concatenate_output_shape - invalid axis", .{});
 
     var shapes = [_][]const usize{
         &[_]usize{ 2, 2 },
@@ -2320,7 +2322,7 @@ test "get_concatenate_output_shape - invalid axis" {
 }
 
 test "neg - 2D tensor" {
-    std.debug.print("\n     test: neg - 2D tensor", .{});
+    tests_log.info("\n     test: neg - 2D tensor", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -2368,7 +2370,7 @@ test "neg - 2D tensor" {
 }
 
 test "neg - 3D tensor" {
-    std.debug.print("\n     test: neg - 3D tensor", .{});
+    tests_log.info("\n     test: neg - 3D tensor", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -2410,7 +2412,7 @@ test "neg - 3D tensor" {
 }
 
 test "get_split_output_shapes - basic functionality" {
-    std.debug.print("\n     test: get_split_output_shapes - basic functionality", .{});
+    tests_log.info("\n     test: get_split_output_shapes - basic functionality", .{});
 
     // Test case 1: Split along axis 1 - using shape that's evenly divisible by 2
     {
@@ -2457,7 +2459,7 @@ test "get_split_output_shapes - basic functionality" {
 }
 
 test "get_split_output_shapes - negative axis" {
-    std.debug.print("\n     test: get_split_output_shapes - negative axis", .{});
+    tests_log.info("\n     test: get_split_output_shapes - negative axis", .{});
 
     var input_shape = [_]usize{ 2, 6, 3 };
     var split_sizes = [_]usize{ 2, 4 };
@@ -2483,7 +2485,7 @@ test "get_split_output_shapes - negative axis" {
 }
 
 test "get_split_output_shapes - error cases" {
-    std.debug.print("\n     test: get_split_output_shapes - error cases", .{});
+    tests_log.info("\n     test: get_split_output_shapes - error cases", .{});
 
     var input_shape = [_]usize{ 2, 3, 4 };
 
@@ -2523,7 +2525,7 @@ test "get_split_output_shapes - error cases" {
 }
 
 test "get_split_output_shapes - default split" {
-    std.debug.print("\n     test: get_split_output_shapes - default split", .{});
+    tests_log.info("\n     test: get_split_output_shapes - default split", .{});
 
     // When split_sizes is null, should split into equal parts
     var input_shape = [_]usize{ 2, 3, 4 };
@@ -2718,7 +2720,7 @@ test "lean_shape_onnx operations and error cases" {
 }
 
 test "slice_onnx basic operations" {
-    // std.debug.print("\n     test: slice_onnx basic operations", .{});
+    // tests_log.info("\n     test: slice_onnx basic operations", .{});
     // const allocator = pkgAllocator.allocator;
 
     // Test 1: Basic 3D slicing
@@ -2798,7 +2800,7 @@ test "slice_onnx basic operations" {
 }
 
 test "get_slice_output_shape basic operations" {
-    std.debug.print("\n     test: get_slice_output_shape basic operations", .{});
+    tests_log.info("\n     test: get_slice_output_shape basic operations", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test 1: Basic 3D slicing
@@ -2868,7 +2870,7 @@ test "get_slice_output_shape basic operations" {
 }
 
 test "identity" {
-    std.debug.print("\n test: identity basic operations\n", .{});
+    tests_log.info("\n test: identity basic operations\n", .{});
     const allocator = pkgAllocator.allocator;
     {
         //check output correctness
@@ -2910,7 +2912,7 @@ test "identity" {
         //check that the output is not the same alias as the input
         try std.testing.expect(result.data.ptr != tensor.data.ptr);
 
-        std.debug.print("OK: identity test passed.\n", .{});
+        tests_log.debug("OK: identity test passed.\n", .{});
     }
 }
 
@@ -2932,7 +2934,7 @@ test "get_identity_shape_output returns a copy of the input shape" {
 }
 
 test "get_pads_output_shape - basic" {
-    std.debug.print("\n     test: get_pads_output_shape - basic", .{});
+    tests_log.info("\n     test: get_pads_output_shape - basic", .{});
     const allocator = pkgAllocator.allocator;
 
     var input_shape = [_]usize{ 3, 4 };
@@ -2947,7 +2949,7 @@ test "get_pads_output_shape - basic" {
 }
 
 test "get_pads_output_shape - with axes" {
-    std.debug.print("\n     test: get_pads_output_shape - with axes", .{});
+    tests_log.info("\n     test: get_pads_output_shape - with axes", .{});
     const allocator = pkgAllocator.allocator;
 
     var input_shape = [_]usize{ 3, 4, 5 };
@@ -2964,7 +2966,7 @@ test "get_pads_output_shape - with axes" {
 }
 
 test "get_pads_output_shape - negative axes" {
-    std.debug.print("\n     test: get_pads_output_shape - negative axes", .{});
+    tests_log.info("\n     test: get_pads_output_shape - negative axes", .{});
     const allocator = pkgAllocator.allocator;
 
     var input_shape = [_]usize{ 3, 4, 5 };
@@ -2981,7 +2983,7 @@ test "get_pads_output_shape - negative axes" {
 }
 
 test "get_pads_output_shape - error cases" {
-    std.debug.print("\n     test: get_pads_output_shape - error cases", .{});
+    tests_log.info("\n     test: get_pads_output_shape - error cases", .{});
     const allocator = pkgAllocator.allocator;
     var input_shape = [_]usize{ 3, 4 };
 
@@ -3029,7 +3031,7 @@ fn expectTensorEqual(comptime T: type, expected: *const Tensor(T), actual: *cons
 
 // Test Case 1: Constant Mode (like ONNX Example 1)
 test "pads constant mode basic 2D" {
-    std.debug.print("\n     test: pads constant mode basic 2D", .{});
+    tests_log.info("\n     test: pads constant mode basic 2D", .{});
     const allocator = pkgAllocator.allocator;
 
     var data_array = [_][2]f32{
@@ -3063,7 +3065,7 @@ test "pads constant mode basic 2D" {
 
 // Test Case 2: Constant Mode with specific value and axes
 test "pads constant mode with value and axes" {
-    std.debug.print("\n     test: pads constant mode with value and axes", .{});
+    tests_log.info("\n     test: pads constant mode with value and axes", .{});
     const allocator = pkgAllocator.allocator;
 
     var data_array = [_]i32{ 1, 2, 3 };
@@ -3094,7 +3096,7 @@ test "pads constant mode with value and axes" {
 
 // Test Case 4: Edge Mode (like ONNX Example 3)
 test "pads edge mode basic 2D" {
-    std.debug.print("\n     test: pads edge mode basic 2D", .{});
+    tests_log.info("\n     test: pads edge mode basic 2D", .{});
     const allocator = pkgAllocator.allocator;
 
     var data_array = [_][2]f32{
@@ -3128,7 +3130,7 @@ test "pads edge mode basic 2D" {
 
 // Test Case 5: Wrap Mode (like ONNX Example 4)
 test "pads wrap mode basic 2D" {
-    std.debug.print("\n     test: pads wrap mode basic 2D", .{});
+    tests_log.info("\n     test: pads wrap mode basic 2D", .{});
     const allocator = pkgAllocator.allocator;
 
     var data_array = [_][2]f32{
@@ -3175,7 +3177,7 @@ test "pads wrap mode basic 2D" {
 
 // Test Case 6: Padding a 3D tensor with constant mode
 test "pads constant mode 3D" {
-    std.debug.print("\n     test: pads constant mode 3D", .{});
+    tests_log.info("\n     test: pads constant mode 3D", .{});
     const allocator = pkgAllocator.allocator;
 
     var data_array = [_][2][2]u8{
@@ -3226,7 +3228,7 @@ test "pads constant mode 3D" {
 
 // Test Case 7: Zero padding (should be identity)
 test "pads zero padding" {
-    std.debug.print("\n     test: pads zero padding", .{});
+    tests_log.info("\n     test: pads zero padding", .{});
     const allocator = pkgAllocator.allocator;
 
     var data_array = [_][2]f32{
@@ -3250,7 +3252,7 @@ test "pads zero padding" {
 }
 
 test "Flatten - Basic" {
-    std.debug.print("\n     test: Flatten - Basic ", .{});
+    tests_log.info("\n     test: Flatten - Basic ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3 tensor
@@ -3282,7 +3284,7 @@ test "Flatten - Basic" {
 }
 
 test "Flatten - Multi-dimensional" {
-    std.debug.print("\n     test: Flatten - Multi-dimensional ", .{});
+    tests_log.info("\n     test: Flatten - Multi-dimensional ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3x4 tensor
@@ -3319,7 +3321,7 @@ test "Flatten - Multi-dimensional" {
 }
 
 test "Flatten - Negative axis" {
-    std.debug.print("\n     test: Flatten - Negative axis ", .{});
+    tests_log.info("\n     test: Flatten - Negative axis ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3x4 tensor
@@ -3356,7 +3358,7 @@ test "Flatten - Negative axis" {
 }
 
 test "Flatten - Axis zero" {
-    std.debug.print("\n     test: Flatten - Axis zero ", .{});
+    tests_log.info("\n     test: Flatten - Axis zero ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3x4 tensor
@@ -3393,7 +3395,7 @@ test "Flatten - Axis zero" {
 }
 
 test "Flatten - Axis equal to rank" {
-    std.debug.print("\n     test: Flatten - Axis equal to rank ", .{});
+    tests_log.info("\n     test: Flatten - Axis equal to rank ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3x4 tensor
@@ -3430,7 +3432,7 @@ test "Flatten - Axis equal to rank" {
 }
 
 test "Flatten - Scalar tensor" {
-    std.debug.print("\n     test: Flatten - Scalar tensor ", .{});
+    tests_log.info("\n     test: Flatten - Scalar tensor ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a scalar tensor
@@ -3454,7 +3456,7 @@ test "Flatten - Scalar tensor" {
 }
 
 test "Flatten - Empty tensor" {
-    std.debug.print("\n     test: Flatten - Empty tensor ", .{});
+    tests_log.info("\n     test: Flatten - Empty tensor ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create an empty tensor: [0, 3, 4]
@@ -3476,7 +3478,7 @@ test "Flatten - Empty tensor" {
 }
 
 test "Flatten - Invalid axis" {
-    std.debug.print("\n     test: Flatten - Invalid axis ", .{});
+    tests_log.info("\n     test: Flatten - Invalid axis ", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create a 2x3x4 tensor

--- a/tests/Core/Tensor/TensorMath/test_op_convolution.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_convolution.zig
@@ -5,8 +5,10 @@ const TensMath = zant.core.tensor.math_standard;
 const Tensor = zant.core.tensor.Tensor;
 const TensorMathError = zant.utils.error_handler.TensorMathError;
 
+const tests_log = std.log.scoped(.test_conv);
+
 test "Convolution 4D Input with 2x2x2x2 Kernel shape" {
-    std.debug.print("\n     test: Convolution 4D Input with 2x2x2x2 Kernel shape\n", .{});
+    tests_log.info("\n     test: Convolution 4D Input with 2x2x2x2 Kernel shape\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -131,7 +133,7 @@ test "Convolution 4D Input with 2x2x2x2 Kernel shape" {
                 output_location[2] = row;
                 for (0..2) |col| {
                     output_location[3] = col;
-                    //std.debug.print("\n get OUTPUT at:{any}", .{output_location});
+                    //tests_log.info("\n get OUTPUT at:{any}", .{output_location});
                     try std.testing.expectEqual(expected_result[batch][filter][row][col], result_tensor.get_at(output_location));
                 }
             }
@@ -140,7 +142,7 @@ test "Convolution 4D Input with 2x2x2x2 Kernel shape" {
 }
 
 test "OnnxConvLean - NOTSET padding" {
-    std.debug.print("\n     test: OnnxConvLean - NOTSET padding\n", .{});
+    tests_log.info("\n     test: OnnxConvLean - NOTSET padding\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -197,7 +199,7 @@ test "OnnxConvLean - NOTSET padding" {
 }
 
 test "OnnxConvLean - SAME_UPPER padding" {
-    std.debug.print("\n     test: OnnxConvLean - SAME_UPPER padding\n", .{});
+    tests_log.info("\n     test: OnnxConvLean - SAME_UPPER padding\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -243,15 +245,15 @@ test "OnnxConvLean - SAME_UPPER padding" {
     try TensMath.conv_lean(f32, &input_tensor, &kernel_tensor, &output_tensor, null, &stride, null, null, null, auto_pad);
 
     // Add debug prints for padded input
-    std.debug.print("\nKernel values:\n", .{});
+    tests_log.debug("\nKernel values:\n", .{});
     var k_row: usize = 0;
     while (k_row < 3) : (k_row += 1) {
         var k_col: usize = 0;
         while (k_col < 3) : (k_col += 1) {
             const idx = k_row * 3 + k_col;
-            std.debug.print("{d:4.1} ", .{kernel_tensor.data[idx]});
+            tests_log.debug("{d:4.1} ", .{kernel_tensor.data[idx]});
         }
-        std.debug.print("\n", .{});
+        tests_log.debug("\n", .{});
     }
 
     try std.testing.expectEqual(@as(usize, 1), output_tensor.shape[0]); // batch
@@ -268,39 +270,39 @@ test "OnnxConvLean - SAME_UPPER padding" {
         4, 6, 6, 6, 4,
     };
 
-    std.debug.print("\nResult shape: {any}\n", .{output_tensor.shape});
-    std.debug.print("\nActual values:\n", .{});
+    tests_log.debug("\nResult shape: {any}\n", .{output_tensor.shape});
+    tests_log.debug("\nActual values:\n", .{});
     var row: usize = 0;
     while (row < 5) : (row += 1) {
         var col: usize = 0;
         while (col < 5) : (col += 1) {
             const idx = row * 5 + col;
-            std.debug.print("{d:4.1} ", .{output_tensor.data[idx]});
+            tests_log.debug("{d:4.1} ", .{output_tensor.data[idx]});
         }
-        std.debug.print("\n", .{});
+        tests_log.debug("\n", .{});
     }
 
-    std.debug.print("\nExpected values:\n", .{});
+    tests_log.debug("\nExpected values:\n", .{});
     row = 0;
     while (row < 5) : (row += 1) {
         var col: usize = 0;
         while (col < 5) : (col += 1) {
             const idx = row * 5 + col;
-            std.debug.print("{d:4.1} ", .{expected_values[idx]});
+            tests_log.debug("{d:4.1} ", .{expected_values[idx]});
         }
-        std.debug.print("\n", .{});
+        tests_log.debug("\n", .{});
     }
 
     for (output_tensor.data, 0..) |val, i| {
         if (val != expected_values[i]) {
-            std.debug.print("\nMismatch at index {d}: expected {d}, got {d}\n", .{ i, expected_values[i], val });
+            tests_log.debug("\nMismatch at index {d}: expected {d}, got {d}\n", .{ i, expected_values[i], val });
         }
         try std.testing.expectEqual(expected_values[i], val);
     }
 }
 
 test "OnnxConvLean - with bias and dilation" {
-    std.debug.print("\n     test: OnnxConvLean - with bias and dilation\n", .{});
+    tests_log.info("\n     test: OnnxConvLean - with bias and dilation\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -362,7 +364,7 @@ test "OnnxConvLean - with bias and dilation" {
 }
 
 test "OnnxConv - all padding modes and features" {
-    std.debug.print("\n     test: OnnxConv - all padding modes and features\n", .{});
+    tests_log.info("\n     test: OnnxConv - all padding modes and features\n", .{});
 
     const allocator = pkgAllocator.allocator;
 

--- a/tests/Core/Tensor/TensorMath/test_op_elu.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_elu.zig
@@ -6,8 +6,10 @@ const Tensor = zant.core.tensor.Tensor;
 const TensorMathError = zant.utils.error_handler.TensorMathError;
 const TensMath = zant.core.tensor.math_standard;
 
+const tests_log = std.log.scoped(.test_elu);
+
 test "elu_standard - basic case" {
-    std.debug.print("\n     test: elu_standard - basic case", .{});
+    tests_log.info("\n     test: elu_standard - basic case", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{3};
     var inputArray = [_]f32{ 1.0, -2.0, 0.0 };
@@ -26,7 +28,7 @@ test "elu_standard - basic case" {
 }
 
 test "elu_standard - different alpha" {
-    std.debug.print("\n     test: elu_standard - different alpha", .{});
+    tests_log.info("\n     test: elu_standard - different alpha", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{3};
     var inputArray = [_]f32{ 1.0, -2.0, 0.0 };
@@ -45,7 +47,7 @@ test "elu_standard - different alpha" {
 }
 
 test "elu_standard - single element" {
-    std.debug.print("\n     test: elu_standard - single element", .{});
+    tests_log.info("\n     test: elu_standard - single element", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{1};
     var inputArray = [_]f32{-1.0};
@@ -64,7 +66,7 @@ test "elu_standard - single element" {
 }
 
 test "elu_standard - empty tensor" {
-    std.debug.print("\n     test: elu_standard - empty tensor", .{});
+    tests_log.info("\n     test: elu_standard - empty tensor", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{0};
 
@@ -79,7 +81,7 @@ test "elu_standard - empty tensor" {
 }
 
 test "elu_standard - invalid type" {
-    std.debug.print("\n     test: elu_standard - invalid type", .{});
+    tests_log.info("\n     test: elu_standard - invalid type", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{3};
     var inputArray = [_]i32{ 1, -2, 0 };
@@ -89,12 +91,12 @@ test "elu_standard - invalid type" {
 
     try std.testing.expectError(TensorMathError.InvalidDataType, TensMath.elu(i32, &input, 1.0));
     _ = TensMath.elu(i32, &input, 1.0) catch |err| {
-        std.debug.print("\n     Error: {s}", .{zant.utils.error_handler.errorDetails(err)});
+        tests_log.warn("\n     Error: {s}", .{zant.utils.error_handler.errorDetails(err)});
     };
 }
 
 test "elu_standard - non 1D input" {
-    std.debug.print("\n     test: elu_standard - non 1D input", .{});
+    tests_log.info("\n     test: elu_standard - non 1D input", .{});
     const allocator = pkgAllocator.allocator;
     var shape = [_]usize{ 2, 2 };
     var inputArray = [_]f32{ 1.0, -2.0, 0.0, 1.0 };
@@ -104,6 +106,6 @@ test "elu_standard - non 1D input" {
 
     try std.testing.expectError(TensorMathError.InvalidInput, TensMath.elu(f32, &input, 1.0));
     _ = TensMath.elu(f32, &input, 1.0) catch |err| {
-        std.debug.print("\n     Error: {s}", .{zant.utils.error_handler.errorDetails(err)});
+        tests_log.warn("\n     Error: {s}", .{zant.utils.error_handler.errorDetails(err)});
     };
 }

--- a/tests/Core/Tensor/TensorMath/test_op_gemm.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_gemm.zig
@@ -9,10 +9,12 @@ const TensorMathError = error_handler.TensorMathError;
 const TensorError = error_handler.TensorError;
 const ErrorHandler = error_handler;
 
+const tests_log = std.log.scoped(.test_gemm);
+
 // TODO: add test for multiple batch/channel
 
 test "Gemm Y = a A*B" {
-    std.debug.print("\n     test: Gemm Y = a A*B", .{});
+    tests_log.info("\n     test: Gemm Y = a A*B", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -37,7 +39,7 @@ test "Gemm Y = a A*B" {
 }
 
 test "Gemm Y = a A*B + bC without broadcasting" {
-    std.debug.print("\n     test: Gemm Y = a A*B + bC without broadcasting", .{});
+    tests_log.info("\n     test: Gemm Y = a A*B + bC without broadcasting", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -69,7 +71,7 @@ test "Gemm Y = a A*B + bC without broadcasting" {
 }
 
 test "Gemm Y = a A*B + bC with broadcasting" {
-    std.debug.print("\n     test: Gemm Y = a A*B + bC with broadcasting", .{});
+    tests_log.info("\n     test: Gemm Y = a A*B + bC with broadcasting", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -107,7 +109,7 @@ test "Gemm Y = a A*B + bC with broadcasting" {
 }
 
 test "Gemm Y = a A*B + bC with broadcasting, custom parameters v1" {
-    std.debug.print("\n     test: Gemm Y = a A*B + bC with broadcasting, custom parameters v1", .{});
+    tests_log.info("\n     test: Gemm Y = a A*B + bC with broadcasting, custom parameters v1", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -144,7 +146,7 @@ test "Gemm Y = a A*B + bC with broadcasting, custom parameters v1" {
 }
 
 test "Gemm Y = a A*B + bC with broadcasting, custom parameters v2" {
-    std.debug.print("\n     test: Gemm Y = a A*B + bC with broadcasting, custom parameters v2", .{});
+    tests_log.info("\n     test: Gemm Y = a A*B + bC with broadcasting, custom parameters v2", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -194,7 +196,7 @@ test "Gemm Y = a A*B + bC with broadcasting, custom parameters v2" {
 
 // NOTE: as 22/02 this test is not passed as mat_mul, used by gemm, doesn't support multiplication of matrix distribuited in multiple batches/channels but only tensor with a shape like {1, 1, N, M}, once mat_mul is updated this test should pass
 // test "Gemm Y = a A*B + bC with broadcasting, custom parameters, multiple batch/channels" {
-//     std.debug.print("\n     test: Gemm Y = a A*B + bC with broadcasting, custom parameters, multiple batch/channels", .{});
+//     tests_log.info("\n     test: Gemm Y = a A*B + bC with broadcasting, custom parameters, multiple batch/channels", .{});
 
 //     const allocator = pkgAllocator.allocator;
 
@@ -264,7 +266,7 @@ test "Gemm Y = a A*B + bC with broadcasting, custom parameters v2" {
 
 //     debug
 //     for (0..result_tensor.data.len) |i|
-//         std.debug.print("\nres[{d}] {d}", .{ i, result_tensor.data[i] });
+//         tests_log.info("\nres[{d}] {d}", .{ i, result_tensor.data[i] });
 
 //     try std.testing.expect(2549.0 == result_tensor.data[12]);
 //     try std.testing.expect(2927.0 == result_tensor.data[13]);
@@ -278,7 +280,7 @@ test "Gemm Y = a A*B + bC with broadcasting, custom parameters v2" {
 // }
 
 test "Error when input tensors aren't 4D" {
-    std.debug.print("\n     test: Error when input tensors aren't 4D", .{});
+    tests_log.info("\n     test: Error when input tensors aren't 4D", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -290,14 +292,14 @@ test "Error when input tensors aren't 4D" {
     try std.testing.expectError(TensorMathError.InputTensorsWrongShape, TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false));
 
     _ = TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false) catch |err| {
-        std.debug.print("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
+        tests_log.warn("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
     };
     t1.deinit();
     t2.deinit();
 }
 
 test "Error when there's a mismatch in batch or channel dimension" {
-    std.debug.print("\n     test: Error when there's a mismatch in batch or channel dimension", .{});
+    tests_log.info("\n     test: Error when there's a mismatch in batch or channel dimension", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -309,14 +311,14 @@ test "Error when there's a mismatch in batch or channel dimension" {
     try std.testing.expectError(TensorMathError.InputTensorDifferentShape, TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false));
 
     _ = TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false) catch |err| {
-        std.debug.print("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
+        tests_log.warn("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
     };
     t1.deinit();
     t2.deinit();
 }
 
 test "Error when input tensors have incompatible sizes for gemm" {
-    std.debug.print("\n     test: Error when input tensors have incompatible sizes for gemm", .{});
+    tests_log.info("\n     test: Error when input tensors have incompatible sizes for gemm", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -328,7 +330,7 @@ test "Error when input tensors have incompatible sizes for gemm" {
     try std.testing.expectError(TensorMathError.InputTensorDimensionMismatch, TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false));
 
     _ = TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false) catch |err| {
-        std.debug.print("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
+        tests_log.warn("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
     };
     t1.deinit();
     t2.deinit();

--- a/tests/Core/Tensor/TensorMath/test_op_mat_mul.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_mat_mul.zig
@@ -6,8 +6,10 @@ const Tensor = zant.core.tensor.Tensor;
 const TensorMathError = zant.utils.error_handler.TensorMathError;
 const ErrorHandler = zant.utils.error_handler;
 
+const tests_log = std.log.scoped(.test_matMul);
+
 test "MatMul 2x2" {
-    std.debug.print("\n     test:MatMul 2x2", .{});
+    tests_log.info("\n     test:MatMul 2x2", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -42,14 +44,14 @@ test "Error when input tensors have incompatible sizes for MatMul" {
     try std.testing.expectError(TensorMathError.InputTensorsWrongShape, TensMath.mat_mul(f32, &t1, &t2));
 
     _ = TensMath.mat_mul(f32, &t1, &t2) catch |err| {
-        std.debug.print("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
+        tests_log.warn("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
     };
     t1.deinit();
     t2.deinit();
 }
 
 test "Error when input tensors have incompatible shapes for MatMul" {
-    std.debug.print("\n     test: Error when input tensors have incompatible shapes for MatMul", .{});
+    tests_log.info("\n     test: Error when input tensors have incompatible shapes for MatMul", .{});
     const allocator = pkgAllocator.allocator;
 
     var shape1: [2]usize = [_]usize{ 2, 2 }; // 2x2 matrix
@@ -64,7 +66,7 @@ test "Error when input tensors have incompatible shapes for MatMul" {
 }
 
 test "Compare MatMul implementations with execution time" {
-    std.debug.print("\nTest: Compare MatMul implementations with execution time\n", .{});
+    tests_log.info("\nTest: Compare MatMul implementations with execution time\n", .{});
     const allocator = pkgAllocator.allocator;
 
     // Create test tensors
@@ -108,10 +110,10 @@ test "Compare MatMul implementations with execution time" {
     const avg_simd = @divFloor(total_simd, iterations);
     const avg_flat = @divFloor(total_flat, iterations);
 
-    std.debug.print("Average over {d} iterations:\n", .{iterations});
-    std.debug.print("SIMD execution time: {d} ns\n", .{avg_simd});
-    std.debug.print("Flat execution time: {d} ns\n", .{avg_flat});
-    std.debug.print("SIMD is {d:.2}x {s}\n", .{ if (avg_simd < avg_flat)
+    tests_log.debug("Average over {d} iterations:\n", .{iterations});
+    tests_log.debug("SIMD execution time: {d} ns\n", .{avg_simd});
+    tests_log.debug("Flat execution time: {d} ns\n", .{avg_flat});
+    tests_log.debug("SIMD is {d:.2}x {s}\n", .{ if (avg_simd < avg_flat)
         @as(f64, @floatFromInt(avg_flat)) / @as(f64, @floatFromInt(avg_simd))
     else
         @as(f64, @floatFromInt(avg_simd)) / @as(f64, @floatFromInt(avg_flat)), if (avg_simd < avg_flat) "faster" else "slower" });

--- a/tests/Core/Tensor/TensorMath/test_op_mean.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_mean.zig
@@ -9,9 +9,11 @@ const TensorMathError = error_handler.TensorMathError;
 const TensorError = error_handler.TensorError;
 const ErrorHandler = error_handler;
 
+const tests_log = std.log.scoped(.test_mean);
+
 // Test per mean_standard e mean_lean
 test "mean_standard - basic case" {
-    std.debug.print("\n     test: mean_standard - basic case", .{});
+    tests_log.info("\n     test: mean_standard - basic case", .{});
     const allocator = std.testing.allocator;
     var shape1 = [_]usize{ 2, 2 };
     var shape2 = [_]usize{ 2, 2 };
@@ -32,7 +34,7 @@ test "mean_standard - basic case" {
 }
 
 test "mean_lean - basic case" {
-    std.debug.print("\n     test: mean_lean - basic case", .{});
+    tests_log.info("\n     test: mean_lean - basic case", .{});
     const allocator = pkgAllocator.allocator;
     // Stesso caso base, ma con mean_lean
     var shape1 = [_]usize{ 2, 2 };
@@ -56,7 +58,7 @@ test "mean_lean - basic case" {
 }
 
 test "mean_standard - broadcasting" {
-    std.debug.print("\n     test: mean_standard - broadcasting", .{});
+    tests_log.info("\n     test: mean_standard - broadcasting", .{});
     const allocator = pkgAllocator.allocator;
     // Test con broadcasting: [1, 3] e [2, 3]
     var shape1 = [_]usize{ 1, 3 };
@@ -79,7 +81,7 @@ test "mean_standard - broadcasting" {
 }
 
 test "mean_standard - single input" {
-    std.debug.print("\n     test: mean_standard - single input", .{});
+    tests_log.info("\n     test: mean_standard - single input", .{});
     const allocator = pkgAllocator.allocator;
     // Edge case: un solo tensore
     var shape1 = [_]usize{ 2, 2 };
@@ -96,7 +98,7 @@ test "mean_standard - single input" {
 }
 
 test "mean_standard - empty tensor list" {
-    std.debug.print("\n     test: mean_standard - empty tensor list", .{});
+    tests_log.info("\n     test: mean_standard - empty tensor list", .{});
     // Edge case: lista vuota
     const inputs = [_]*Tensor(f32){};
     const result = TensMath.mean_standard(f32, &inputs);
@@ -104,7 +106,7 @@ test "mean_standard - empty tensor list" {
 }
 
 test "mean_standard - invalid type" {
-    std.debug.print("\n     test: mean_standard - invalid type", .{});
+    tests_log.info("\n     test: mean_standard - invalid type", .{});
     const allocator = pkgAllocator.allocator;
     // Edge case: tipo non supportato (es. i32)
     var shape1 = [_]usize{ 2, 2 };
@@ -116,7 +118,7 @@ test "mean_standard - invalid type" {
     try std.testing.expectError(TensorMathError.InvalidDataType, TensMath.mean_standard(i32, &inputs));
 
     _ = TensMath.mean_standard(i32, &inputs) catch |err| {
-        std.debug.print("\n     Error: {s}", .{ErrorHandler.errorDetails(err)});
+        tests_log.warn("\n     Error: {s}", .{ErrorHandler.errorDetails(err)});
     };
 }
 
@@ -137,7 +139,7 @@ test "mean_standard - invalid type" {
 
 //     try std.testing.expectError(TensorMathError.MismatchedDataTypes, TensMath.mean_standard(f32, &inputs));
 //     _ = TensMath.mean_standard(f32, &inputs) catch |err| {
-//         std.debug.print("\n     Error: {s}", .{ErrorHandler.errorDetails(err)});
+//         tests_log.warn("\n     Error: {s}", .{ErrorHandler.errorDetails(err)});
 //     };
 
 //     t1.deinit();
@@ -145,7 +147,7 @@ test "mean_standard - invalid type" {
 // }
 
 test "mean_standard - multidimensional broadcasting" {
-    std.debug.print("\n     test: mean_standard - multidimensional broadcasting", .{});
+    tests_log.info("\n     test: mean_standard - multidimensional broadcasting", .{});
     const allocator = std.testing.allocator;
     var shape1 = [_]usize{ 1, 1, 2 };
     var shape2 = [_]usize{ 2, 2, 2 };

--- a/tests/Core/Tensor/TensorMath/test_op_pooling.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_pooling.zig
@@ -6,8 +6,10 @@ const Tensor = zant.core.tensor.Tensor;
 const PoolingType = zant.core.tensor.math_standard.PoolingType;
 const AutoPadType = zant.core.tensor.math_standard.AutoPadType;
 
+const tests_log = std.log.scoped(.test_pooling);
+
 test "Pooling 2D" {
-    std.debug.print("\n     test: Pooling 2D\n", .{});
+    tests_log.info("\n     test: Pooling 2D\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -101,7 +103,7 @@ test "Pooling 2D" {
 }
 
 test "Pooling multidim" {
-    std.debug.print("\n     test: Pooling multidim\n", .{});
+    tests_log.info("\n     test: Pooling multidim\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -154,7 +156,7 @@ test "Pooling multidim" {
 }
 
 test "ONNX MaxPool - NOTSET padding" {
-    std.debug.print("\n     test: ONNX MaxPool - NOTSET padding\n", .{});
+    tests_log.info("\n     test: ONNX MaxPool - NOTSET padding\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -202,7 +204,7 @@ test "ONNX MaxPool - NOTSET padding" {
 }
 
 test "ONNX MaxPool - SAME_UPPER padding" {
-    std.debug.print("\n     test: ONNX MaxPool - SAME_UPPER padding\n", .{});
+    tests_log.info("\n     test: ONNX MaxPool - SAME_UPPER padding\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -254,7 +256,7 @@ test "ONNX MaxPool - SAME_UPPER padding" {
 }
 
 test "ONNX MaxPool - with dilation" {
-    std.debug.print("\n     test: ONNX MaxPool - with dilation\n", .{});
+    tests_log.info("\n     test: ONNX MaxPool - with dilation\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -304,7 +306,7 @@ test "ONNX MaxPool - with dilation" {
 }
 
 test "ONNX MaxPool - ceil mode" {
-    std.debug.print("\n     test: ONNX MaxPool - ceil mode\n", .{});
+    tests_log.info("\n     test: ONNX MaxPool - ceil mode\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -351,7 +353,7 @@ test "ONNX MaxPool - ceil mode" {
 }
 
 test "ONNX MaxPool - explicit padding" {
-    std.debug.print("\n     test: ONNX MaxPool - explicit padding\n", .{});
+    tests_log.info("\n     test: ONNX MaxPool - explicit padding\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -416,7 +418,7 @@ test "ONNX MaxPool - explicit padding" {
 }
 
 test "ONNX AveragePool - NOTSET padding" {
-    std.debug.print("\n     test: ONNX AveragePool - NOTSET padding\n", .{});
+    tests_log.info("\n     test: ONNX AveragePool - NOTSET padding\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -462,7 +464,7 @@ test "ONNX AveragePool - NOTSET padding" {
 }
 
 test "ONNX AveragePool - SAME_UPPER padding" {
-    std.debug.print("\n     test: ONNX AveragePool - SAME_UPPER padding\n", .{});
+    tests_log.info("\n     test: ONNX AveragePool - SAME_UPPER padding\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -512,7 +514,7 @@ test "ONNX AveragePool - SAME_UPPER padding" {
 }
 
 test "ONNX AveragePool - with dilation" {
-    std.debug.print("\n     test: ONNX AveragePool - with dilation\n", .{});
+    tests_log.info("\n     test: ONNX AveragePool - with dilation\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -558,7 +560,7 @@ test "ONNX AveragePool - with dilation" {
 }
 
 test "ONNX AveragePool - ceil mode" {
-    std.debug.print("\n     test: ONNX AveragePool - ceil mode\n", .{});
+    tests_log.info("\n     test: ONNX AveragePool - ceil mode\n", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -603,7 +605,7 @@ test "ONNX AveragePool - ceil mode" {
 }
 
 test "ONNX AveragePool - explicit padding with count_include_pad" {
-    std.debug.print("\n     test: ONNX AveragePool - explicit padding with count_include_pad\n", .{});
+    tests_log.info("\n     test: ONNX AveragePool - explicit padding with count_include_pad\n", .{});
 
     const allocator = pkgAllocator.allocator;
 

--- a/tests/Core/Tensor/test_tensor.zig
+++ b/tests/Core/Tensor/test_tensor.zig
@@ -5,6 +5,8 @@ const Tensor = zant.core.tensor.Tensor;
 const TensorError = zant.utils.error_handler.TensorError;
 const pkgAllocator = zant.utils.allocator;
 
+const tests_log = std.log.scoped(.test_lib_shape);
+
 const expect = std.testing.expect;
 
 test {
@@ -12,11 +14,11 @@ test {
 }
 
 test "Tensor test description" {
-    std.debug.print("\n--- Running tensor tests\n", .{});
+    tests_log.info("\n--- Running tensor tests\n", .{});
 }
 
 test "init() test" {
-    std.debug.print("\n     test: init() ", .{});
+    tests_log.info("\n     test: init() ", .{});
     const allocator = pkgAllocator.allocator;
     var tensor = try Tensor(f64).init(&allocator);
     defer tensor.deinit();
@@ -26,7 +28,7 @@ test "init() test" {
 }
 
 test "initialization fromShape" {
-    std.debug.print("\n     test:initialization fromShape", .{});
+    tests_log.info("\n     test:initialization fromShape", .{});
     const allocator = pkgAllocator.allocator;
     var shape: [2]usize = [_]usize{ 2, 3 };
     var tensor = try Tensor(f64).fromShape(&allocator, &shape);
@@ -40,7 +42,7 @@ test "initialization fromShape" {
 }
 
 test "Get_Set_Test" {
-    std.debug.print("\n     test:Get_Set_Test", .{});
+    tests_log.info("\n     test:Get_Set_Test", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray: [2][3]u8 = [_][3]u8{
@@ -58,7 +60,7 @@ test "Get_Set_Test" {
 }
 
 test "Flatten Index Test" {
-    std.debug.print("\n     test:Flatten Index Test", .{});
+    tests_log.info("\n     test:Flatten Index Test", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray: [2][3]u8 = [_][3]u8{
@@ -72,16 +74,16 @@ test "Flatten Index Test" {
     var indices = [_]usize{ 1, 2 };
     const flatIndex = try tensor.flatten_index(&indices);
 
-    //std.debug.print("\nflatIndex: {}\n", .{flatIndex});
+    //tests_log.info("\nflatIndex: {}\n", .{flatIndex});
     try std.testing.expect(flatIndex == 5);
     indices = [_]usize{ 0, 0 };
     const flatIndex2 = try tensor.flatten_index(&indices);
-    //std.debug.print("\nflatIndex2: {}\n", .{flatIndex2});
+    //tests_log.info("\nflatIndex2: {}\n", .{flatIndex2});
     try std.testing.expect(flatIndex2 == 0);
 }
 
 test "Get_at Set_at Test" {
-    std.debug.print("\n     test:Get_at Set_at Test", .{});
+    tests_log.info("\n     test:Get_at Set_at Test", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray: [2][3]u8 = [_][3]u8{
@@ -111,7 +113,7 @@ test "Get_at Set_at Test" {
 }
 
 test " copy() method" {
-    std.debug.print("\n     test:copy() method ", .{});
+    tests_log.info("\n     test:copy() method ", .{});
     const allocator = pkgAllocator.allocator;
 
     var inputArray: [2][3]u8 = [_][3]u8{
@@ -135,7 +137,7 @@ test " copy() method" {
 }
 
 test "to array " {
-    std.debug.print("\n     test:to array ", .{});
+    tests_log.info("\n     test:to array ", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -155,7 +157,7 @@ test "to array " {
 }
 
 test "test setToZero() " {
-    std.debug.print("\n     test: setToZero()", .{});
+    tests_log.info("\n     test: setToZero()", .{});
 
     const allocator = pkgAllocator.allocator;
 
@@ -187,7 +189,7 @@ test "test setToZero() " {
 }
 
 // test "slice_onnx basic slicing" {
-//     std.debug.print("\n     test: slice_onnx basic slicing", .{});
+//     tests_log.info("\n     test: slice_onnx basic slicing", .{});
 //     const allocator = pkgAllocator.allocator;
 
 //     // Test 1D tensor slicing
@@ -230,7 +232,7 @@ test "test setToZero() " {
 // }
 
 // test "slice_onnx negative indices" {
-//     std.debug.print("\n     test: slice_onnx negative indices", .{});
+//     tests_log.info("\n     test: slice_onnx negative indices", .{});
 //     const allocator = pkgAllocator.allocator;
 
 //     var input_array = [_]i32{ 1, 2, 3, 4, 5 };
@@ -250,7 +252,7 @@ test "test setToZero() " {
 // }
 
 // test "slice_onnx with steps" {
-//     std.debug.print("\n     test: slice_onnx with steps", .{});
+//     tests_log.info("\n     test: slice_onnx with steps", .{});
 //     const allocator = pkgAllocator.allocator;
 
 //     var input_array = [_]i32{ 1, 2, 3, 4, 5, 6 };
@@ -286,7 +288,7 @@ test "test setToZero() " {
 // }
 
 // test "slice_onnx with explicit axes" {
-//     std.debug.print("\n     test: slice_onnx with explicit axes", .{});
+//     tests_log.info("\n     test: slice_onnx with explicit axes", .{});
 //     const allocator = pkgAllocator.allocator;
 
 //     var input_array = [_][3]i32{
@@ -316,7 +318,7 @@ test "test setToZero() " {
 // }
 
 // test "slice_onnx error cases" {
-//     std.debug.print("\n     test: slice_onnx error cases", .{});
+//     tests_log.info("\n     test: slice_onnx error cases", .{});
 //     const allocator = pkgAllocator.allocator;
 
 //     var input_array = [_]i32{ 1, 2, 3, 4, 5 };
@@ -341,7 +343,7 @@ test "test setToZero() " {
 // }
 
 test "ensure_4D_shape" {
-    std.debug.print("\n     test: ensure_4D_shape ", .{});
+    tests_log.info("\n     test: ensure_4D_shape ", .{});
 
     //shape 1D
     const shape = [_]usize{5};
@@ -366,7 +368,7 @@ test "ensure_4D_shape" {
     try std.testing.expectEqual(result[3], 10);
 
     //shape 3D
-    std.debug.print("\n     test: ensure_4D_shape with 3 dimensions", .{});
+    tests_log.info("\n     test: ensure_4D_shape with 3 dimensions", .{});
 
     const shape_3 = [_]usize{ 5, 10, 15 };
     result = try Tensor(f32).ensure_4D_shape(&shape_3);
@@ -379,7 +381,7 @@ test "ensure_4D_shape" {
     try std.testing.expectEqual(result[3], 15);
 
     //shape 4D
-    std.debug.print("\n     test: ensure_4D_shape with 4 dimensions", .{});
+    tests_log.info("\n     test: ensure_4D_shape with 4 dimensions", .{});
 
     const shape_4 = [_]usize{ 5, 10, 15, 20 };
     result = try Tensor(f32).ensure_4D_shape(&shape_4);
@@ -392,7 +394,7 @@ test "ensure_4D_shape" {
     try std.testing.expectEqual(result[3], 20);
 
     // shape 5D --> check for error
-    std.debug.print("\n     test: ensure_4D_shape with 5 dimensions", .{});
+    tests_log.info("\n     test: ensure_4D_shape with 5 dimensions", .{});
 
     const shape_5 = [_]usize{ 5, 10, 15, 20, 25 };
 
@@ -400,7 +402,7 @@ test "ensure_4D_shape" {
 }
 
 test "benchmark flatten_index implementations" {
-    std.debug.print("\n     test: benchmark flatten_index implementations", .{});
+    tests_log.info("\n     test: benchmark flatten_index implementations", .{});
     const allocator = pkgAllocator.allocator;
 
     // Test with different tensor dimensions
@@ -426,7 +428,7 @@ test "benchmark flatten_index implementations" {
         const avg_original = total_original / benchmark_runs;
         const speedup = @as(f32, @floatFromInt(avg_original)) / @max(1, @as(f32, @floatFromInt(avg_optimized)));
 
-        std.debug.print("\n       1D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
+        tests_log.info("\n       1D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
 
         // Ensure optimized is at least as fast as original
         try std.testing.expect(avg_optimized <= avg_original + 5);
@@ -451,7 +453,7 @@ test "benchmark flatten_index implementations" {
         const avg_original = total_original / benchmark_runs;
         const speedup = @as(f32, @floatFromInt(avg_original)) / @max(1, @as(f32, @floatFromInt(avg_optimized)));
 
-        std.debug.print("\n       2D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
+        tests_log.info("\n       2D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
 
         try std.testing.expect(avg_optimized <= avg_original);
     }
@@ -475,7 +477,7 @@ test "benchmark flatten_index implementations" {
         const avg_original = total_original / benchmark_runs;
         const speedup = @as(f32, @floatFromInt(avg_original)) / @max(1, @as(f32, @floatFromInt(avg_optimized)));
 
-        std.debug.print("\n       3D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
+        tests_log.info("\n       3D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
 
         try std.testing.expect(avg_optimized <= avg_original);
     }
@@ -499,7 +501,7 @@ test "benchmark flatten_index implementations" {
         const avg_original = total_original / benchmark_runs;
         const speedup = @as(f32, @floatFromInt(avg_original)) / @max(1, @as(f32, @floatFromInt(avg_optimized)));
 
-        std.debug.print("\n       4D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
+        tests_log.info("\n       4D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
 
         try std.testing.expect(avg_optimized <= avg_original);
     }
@@ -523,7 +525,7 @@ test "benchmark flatten_index implementations" {
         const avg_original = total_original / benchmark_runs;
         const speedup = @as(f32, @floatFromInt(avg_original)) / @max(1, @as(f32, @floatFromInt(avg_optimized)));
 
-        std.debug.print("\n       5D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
+        tests_log.info("\n       5D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
 
         try std.testing.expect(avg_optimized <= @as(u64, @intFromFloat(@as(f32, @floatFromInt(avg_original)) * 1.1)));
     }
@@ -547,7 +549,7 @@ test "benchmark flatten_index implementations" {
     //     const avg_original = total_original / benchmark_runs;
     //     const speedup = @as(f32, @floatFromInt(avg_original)) / @max(1, @as(f32, @floatFromInt(avg_optimized)));
 
-    //     std.debug.print("\n       6D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
+    //     tests_log.info("\n       6D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
 
     //     try std.testing.expect(avg_optimized <= avg_original + 4);
     // }
@@ -571,7 +573,7 @@ test "benchmark flatten_index implementations" {
     //     const avg_original = total_original / benchmark_runs;
     //     const speedup = @as(f32, @floatFromInt(avg_original)) / @max(1, @as(f32, @floatFromInt(avg_optimized)));
 
-    //     std.debug.print("\n       7D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
+    //     tests_log.info("\n       7D tensor: optimized={d}ms, original={d}ms, speedup={d:.2}x", .{ avg_optimized, avg_original, speedup });
 
     //     try std.testing.expect(avg_optimized <= avg_original + 4);
     // }

--- a/tests/Onnx/onnx_loader.zig
+++ b/tests/Onnx/onnx_loader.zig
@@ -4,6 +4,8 @@ const onnx = zant.onnx;
 const pkgAllocator = zant.utils.allocator;
 const allocator = pkgAllocator.allocator;
 
+const tests_log = std.log.scoped(.test_utils);
+
 const ErrorDetail = struct {
     modelName: []const u8,
     errorLoad: anyerror,
@@ -13,7 +15,7 @@ var models: std.ArrayList([]const u8) = std.ArrayList([]const u8).init(allocator
 var failed_parsed_models: std.ArrayList(ErrorDetail) = std.ArrayList(ErrorDetail).init(allocator);
 
 test " Onnx loader" {
-    std.debug.print("\n     test:  Onnx loader\n", .{});
+    tests_log.info("\n     test:  Onnx loader\n", .{});
 
     var dir = try std.fs.cwd().openDir("datasets/models", .{ .iterate = true });
     defer dir.close();
@@ -46,10 +48,10 @@ test " Onnx loader" {
     }
 
     if (failed_parsed_models.items.len != 0) {
-        std.debug.print("\n\n FAILED ONNX PARSED MODELS: ", .{});
-        for (failed_parsed_models.items) |fm| std.debug.print("\n model:{s} error:{any}", .{ fm.modelName, fm.errorLoad });
+        tests_log.info("\n\n FAILED ONNX PARSED MODELS: ", .{});
+        for (failed_parsed_models.items) |fm| tests_log.info("\n model:{s} error:{any}", .{ fm.modelName, fm.errorLoad });
     } else {
-        std.debug.print("\n\n ---- SUCCESFULLY PARSED ALL ONNX MODELS ---- \n\n", .{});
+        tests_log.info("\n\n ---- SUCCESFULLY PARSED ALL ONNX MODELS ---- \n\n", .{});
     }
 
     models.deinit();

--- a/tests/Utils/test_utils.zig
+++ b/tests/Utils/test_utils.zig
@@ -3,12 +3,14 @@ const zant = @import("zant");
 const conv = zant.utils.type_converter;
 const init = zant.utils.tensor_initializer;
 
+const tests_log = std.log.scoped(.test_utils);
+
 test "Utils description test" {
-    std.debug.print("\n--- Running utils test\n", .{});
+    tests_log.info("\n--- Running utils test\n", .{});
 }
 
 test "convert integer to float" {
-    std.debug.print("\n     convert integer to float", .{});
+    tests_log.info("\n     convert integer to float", .{});
     const result = conv.convert(i32, f64, 42);
     const a: f64 = 42.0;
     try std.testing.expectEqual(a, result);
@@ -16,7 +18,7 @@ test "convert integer to float" {
 }
 
 test "convert float to integer" {
-    std.debug.print("\n     convert float to integer", .{});
+    tests_log.info("\n     convert float to integer", .{});
     const result = conv.convert(f64, i32, 42.9);
     const a: i32 = 42;
     try std.testing.expectEqual(a, result);
@@ -24,47 +26,47 @@ test "convert float to integer" {
 }
 
 test "convert integer to bool" {
-    std.debug.print("\n     convert integer to bool", .{});
+    tests_log.info("\n     convert integer to bool", .{});
     const result = conv.convert(i32, bool, 1);
     try std.testing.expectEqual(bool, @TypeOf(result));
 }
 
 test "convert float to bool" {
-    std.debug.print("\n     convert float to bool", .{});
+    tests_log.info("\n     convert float to bool", .{});
     const result = conv.convert(f64, bool, 0.0);
     try std.testing.expectEqual(false, result);
 }
 
 test "convert true bool to integer" {
-    std.debug.print("\n     convert bool to integer", .{});
+    tests_log.info("\n     convert bool to integer", .{});
     const result = conv.convert(bool, i32, true);
     try std.testing.expectEqual(i32, @TypeOf(result));
     try std.testing.expectEqual(1, result);
 }
 
 test "convert false bool to integer" {
-    std.debug.print("\n     convert bool to integer", .{});
+    tests_log.info("\n     convert bool to integer", .{});
     const result = conv.convert(bool, i32, false);
     try std.testing.expectEqual(i32, @TypeOf(result));
     try std.testing.expectEqual(0, result);
 }
 
 test "convert bool to float" {
-    std.debug.print("\n     convert bool to float", .{});
+    tests_log.info("\n     convert bool to float", .{});
     const result = conv.convert(bool, f64, false);
     try std.testing.expectEqual(0.0, result);
     try std.testing.expectEqual(f64, @TypeOf(result));
 }
 
 test "convert bool to bool" {
-    std.debug.print("\n     convert bool to bool", .{});
+    tests_log.info("\n     convert bool to bool", .{});
     const result = conv.convert(bool, bool, true);
     try std.testing.expectEqual(true, result);
     try std.testing.expectEqual(bool, @TypeOf(result));
 }
 
 test "convert comptime int to float" {
-    std.debug.print("\n     convert comptime int to float", .{});
+    tests_log.info("\n     convert comptime int to float", .{});
     comptime {
         const a = 123;
         const result = conv.convert(@TypeOf(a), f64, a);
@@ -74,7 +76,7 @@ test "convert comptime int to float" {
 }
 
 test "generateRandomSlice allocates correctly" {
-    std.debug.print("\n     Checking allocation in tensorInitializer\n", .{});
+    tests_log.info("\n     Checking allocation in tensorInitializer\n", .{});
     var allocator = std.testing.allocator;
     const slice = try init.generateRandomSlice(f32, allocator, 10, init.InitMethod.Dumb);
     defer allocator.free(slice);
@@ -83,7 +85,7 @@ test "generateRandomSlice allocates correctly" {
 }
 
 test "generateRandomSlice produces only 0 and 1 for Binary" {
-    std.debug.print("\n     Checking binary values in tensorInitializer\n", .{});
+    tests_log.info("\n     Checking binary values in tensorInitializer\n", .{});
     var allocator = std.testing.allocator;
     const slice = try init.generateRandomSlice(u8, allocator, 100, init.InitMethod.Binary);
     defer allocator.free(slice);
@@ -94,7 +96,7 @@ test "generateRandomSlice produces only 0 and 1 for Binary" {
 }
 
 test "generateRandomSlice respects LimitedRange" {
-    std.debug.print("\n     Checking limited range in tensorInitializer\n", .{});
+    tests_log.info("\n     Checking limited range in tensorInitializer\n", .{});
     var allocator = std.testing.allocator;
     const slice = try init.generateRandomSlice(i32, allocator, 100, init.InitMethod.LimitedRange);
     defer allocator.free(slice);
@@ -105,7 +107,7 @@ test "generateRandomSlice respects LimitedRange" {
 }
 
 test "generateRandomSlice respects Gaussian distribution" {
-    std.debug.print("\n     Checking Gaussian distribution in tensorInitializer\n", .{});
+    tests_log.info("\n     Checking Gaussian distribution in tensorInitializer\n", .{});
     var allocator = std.testing.allocator;
     const slice = try init.generateRandomSlice(f64, allocator, 10000, init.InitMethod.Gaussian);
     defer allocator.free(slice);

--- a/tests/test_lib.zig
+++ b/tests/test_lib.zig
@@ -1,7 +1,11 @@
 const std = @import("std");
 
-comptime {
-    _ = @import("Core/Tensor/TensorMath/test_op_convolution.zig");
-    _ = @import("Core/test_core.zig");
-    _ = @import("Utils/test_utils.zig");
+test {
+    std.testing.log_level = .info;
+
+    comptime {
+        _ = @import("Core/Tensor/TensorMath/test_op_convolution.zig");
+        _ = @import("Core/test_core.zig");
+        _ = @import("Utils/test_utils.zig");
+    }
 }


### PR DESCRIPTION

Replaced all usages of std.debug.print with std.log.* throughout the test files, implementing custom log scopes to improve clarity and control over logging output.

use -Doptimize=ReleaseFast if you dont want to print debug messages