### PR TITLE
Teoscura accum/mulacc

### DIFF
--- a/src/CodeGen/renderers/arithmetic_render.zig
+++ b/src/CodeGen/renderers/arithmetic_render.zig
@@ -25,15 +25,16 @@ pub fn render(
 
     const type_str = DTypeInfo.asString(uop.dtype);
 
+    // Generate declaration for the result variable
     switch (uop.op) {
-        .ADD => try writer.print("{s}[0] = {s}[0] + {s}[0]; // ADD (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
-        .SUB => try writer.print("{s}[0] = {s}[0] - {s}[0]; // SUB (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
-        .MUL => try writer.print("{s}[0] = {s}[0] * {s}[0]; // MUL (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
-        .FDIV => try writer.print("{s}[0] = {s}[0] / {s}[0]; // FDIV (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
-        .POW => try writer.print("{s}[0] = std.math.pow({s}, {s}[0], {s}[0]); // POW (uop {d})\n", .{ result_var, type_str, lhs_var, rhs_var, uop.id }),
-        .MAX => try writer.print("{s}[0] = @max({s}[0], {s}[0]); // MAX (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
-        .MIN => try writer.print("{s}[0] = @min({s}[0], {s}[0]); // MIN (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
-        .CMPLT => try writer.print("{s}[0] = ({s}[0] < {s}[0]); // CMPLT (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
+        .ADD => try writer.print("    const {s} = {s} + {s}; // ADD (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
+        .SUB => try writer.print("    const {s} = {s} - {s}; // SUB (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
+        .MUL => try writer.print("    const {s} = {s} * {s}; // MUL (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
+        .FDIV => try writer.print("    const {s} = {s} / {s}; // FDIV (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
+        .POW => try writer.print("    const {s} = std.math.pow({s}, {s}, {s}); // POW (uop {d})\n", .{ result_var, type_str, lhs_var, rhs_var, uop.id }),
+        .MAX => try writer.print("    const {s} = @max({s}, {s}); // MAX (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
+        .MIN => try writer.print("    const {s} = @min({s}, {s}); // MIN (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
+        .CMPLT => try writer.print("    const {s} = ({s} < {s}); // CMPLT (uop {d})\n", .{ result_var, lhs_var, rhs_var, uop.id }),
         else => unreachable,
     }
 }

--- a/src/CodeGen/renderers/gep_render.zig
+++ b/src/CodeGen/renderers/gep_render.zig
@@ -1,103 +1,152 @@
 const std = @import("std");
 const zant = @import("zant");
-const UOp = zant.uops.UOp;
-const DTypeInfo = zant.uops.DTypeInfo;
-const ViewInfo = @import("view_manager.zig").ViewInfo;
 
+const UOp = zant.uops.UOp;
+const ViewInfo = @import("view_manager.zig").ViewInfo;
+const BufferInfo = @import("zig_renderer.zig").BufferInfo;
+const DTypeInfo = zant.uops.DTypeInfo;
+
+pub const RendererError = error{
+    InvalidOp,
+    NoAny,
+    VarMissing,
+    RankMismatch,
+};
+
+/// cast a loop index variable (i32) to a usize expression string
+fn castIndex(
+    alloc: std.mem.Allocator,
+    ptr_map: *std.AutoHashMap(usize, []const u8),
+    id: usize,
+) ![]const u8 {
+    const name = ptr_map.get(id) orelse return RendererError.VarMissing;
+    return std.fmt.allocPrint(alloc, "@as(usize,@intCast({s}))", .{name});
+}
+
+/// emit "expr * stride" (skip if stride == 0)
+fn emitTerm(w: anytype, expr: []const u8, stride: usize, first: *bool) !void {
+    if (stride == 0) return;
+    if (!first.*) try w.print(" + ", .{});
+    try w.print("({s}*{d})", .{ expr, stride });
+    first.* = false;
+}
+
+/// --------  MAIN entry  ---------------------------------------------------
 pub fn render(
-    allocator: std.mem.Allocator,
+    alloc: std.mem.Allocator,
     writer: anytype,
     uop: UOp,
-    view_map: std.AutoHashMap(usize, ViewInfo),
-    ptr_map: *const std.AutoHashMap(usize, []const u8),
+    view_map: *std.AutoHashMap(usize, ViewInfo),
+    buffer_map: *std.AutoHashMap(usize, BufferInfo),
+    ptr_map: *std.AutoHashMap(usize, []const u8),
 ) !void {
-    if (uop.op != .GEP) {
-        return error.InvalidOperation;
-    }
-    if (uop.arg == null) {
-        return error.NoAnyProvided;
-    }
+    // only GEPs handled here
+    if (uop.op != .GEP) return RendererError.InvalidOp;
+    if (uop.arg == null) return RendererError.NoAny;
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const aalloc = arena.allocator();
+    // ------------------------------------------------------------------ //
+    // 1. base pointer name                                               //
+    // ------------------------------------------------------------------ //
 
-    const mem_info = uop.arg.?.mem_info;
-    const offset = mem_info.offset;
-    const stride = mem_info.stride;
-    const type_str = DTypeInfo.asString(uop.dtype);
-    const result_addr_var = ptr_map.get(uop.id) orelse return error.VariableNotFound;
+    // 1) Determine base pointer name (fix for slice vs pointer)
+    const base_id = uop.src[0];
+    var base_ptr: []const u8 = undefined;
 
-    std.debug.print("DEBUG: GepRender looking up base_uop_id: {d} in ptr_map\n", .{uop.src[0]});
-    const base_uop_id = uop.src[0];
-    const base_ptr_expr = ptr_map.get(base_uop_id) orelse {
-        std.debug.print("GEP Error: Base ID {d} not found in ptr_map\n", .{base_uop_id});
-        return error.InvalidOperation;
-    };
-
-    var index_expr_str: []const u8 = undefined;
-    var temp_alloc = std.ArrayList(u8).init(allocator);
-    defer temp_alloc.deinit();
-    var needs_free_index_expr = false;
-
-    const view_id = uop.src[0];
-    if (view_map.get(view_id)) |view_info| {
-        if (uop.src.len == 2) {
-            const index_var_id = uop.src[1];
-            index_expr_str = ptr_map.get(index_var_id) orelse return error.VariableNotFound;
-            needs_free_index_expr = false;
-        } else if (uop.src.len > 2 and uop.src.len - 1 == view_info.arg.view_meta.strides.len) {
-            const strides = view_info.arg.view_meta.strides;
-            const indexes = uop.src;
-            var first_term = true;
-
-            var i: usize = 1;
-            while (i < indexes.len) : (i += 1) {
-                const index_var_id = indexes[i];
-                const view_stride_val = strides[i - 1];
-                const index_var_name = ptr_map.get(index_var_id) orelse return error.VariableNotFound;
-
-                if (view_stride_val != 0) {
-                    if (!first_term) try temp_alloc.writer().print(" + ", .{});
-                    try temp_alloc.writer().print("({s} * {d})", .{ index_var_name, view_stride_val });
-                    first_term = false;
-                }
-            }
-            if (first_term) try temp_alloc.writer().print("0", .{});
-            index_expr_str = temp_alloc.items;
-            needs_free_index_expr = false;
+    if (buffer_map.get(base_id)) |bi| {
+        // bi.name is a slice (e.g. input_0), so for inputs/outputs append .ptr
+        if (bi.is_input or std.mem.startsWith(u8, bi.name, "output_")) {
+            // allocate in the existing arena
+            base_ptr = try std.fmt.allocPrint(aalloc, "{s}.ptr", .{bi.name});
         } else {
-            std.debug.print("GEP Error: src.len ({d}) mismatch with view strides.len ({d}) for view_id {d}\n", .{ uop.src.len, view_info.arg.view_meta.strides.len, view_id });
-            return error.InvalidOperation;
+            // internal buffers (addr_, acc_) are already pointers
+            base_ptr = bi.name;
+        }
+    } else if (ptr_map.get(base_id)) |p| {
+        // temporaries from ptr_map (like addr_3) are already raw pointers
+        base_ptr = p;
+    } else {
+        return RendererError.VarMissing;
+    }
+
+    // ------------------------------------------------------------------ //
+    // 2. build element-offset expression                                 //
+    // ------------------------------------------------------------------ //
+
+    var list = std.ArrayList(u8).init(aalloc);
+    const w = list.writer();
+
+    if (view_map.get(base_id)) |vinfo| {
+        const shape = vinfo.arg.view_meta.shape;
+        const strides = vinfo.arg.view_meta.strides;
+
+        // (a) 1-D linear index into the view  --------------------------
+        if (uop.src.len == 2) {
+            if (shape.len != strides.len) return RendererError.RankMismatch;
+            if (shape.len == 0) return RendererError.RankMismatch;
+
+            const idx_expr = try castIndex(aalloc, ptr_map, uop.src[1]);
+
+            // special-case rank-1 and rank-2 (enough for the tests)
+            if (shape.len == 1) {
+                // contiguous or broadcast vector
+                var first_term = true;
+                try emitTerm(w, idx_expr, @as(usize, @intCast(strides[0])), &first_term);
+            } else if (shape.len == 2) {
+                const cols = shape[1];
+                const s_row = strides[0];
+                const s_col = strides[1];
+                // (i/cols)*s_row + (i%cols)*s_col
+                try w.print(
+                    "((({s}/{d})*{d})+(({s}%{d})*{d}))",
+                    .{ idx_expr, cols, s_row, idx_expr, cols, s_col },
+                );
+            } else {
+                // fall back to slow loop-unflatten (not needed yet)
+                return RendererError.RankMismatch;
+            }
+        }
+        // (b) fully-specified per-dim indexes --------------------------
+        else if (uop.src.len - 1 == strides.len) {
+            var first = true;
+            for (uop.src[1..], 0..) |id, ax| {
+                const idx_expr = try castIndex(aalloc, ptr_map, id);
+                try emitTerm(w, idx_expr, @as(usize, @intCast(strides[ax])), &first);
+            }
+            if (first) try w.print("0", .{});
+        } else {
+            return RendererError.RankMismatch;
         }
     } else {
-        if (uop.src.len != 2) {
-            std.debug.print("GEP Error: Non-view GEP expects src.len == 2, got {d}\n", .{uop.src.len});
-            return error.InvalidOperation;
+        // ----------------------------------------------------------------
+        // raw buffer (no VIEW) – support 1-D or 2-D row-major
+        // ----------------------------------------------------------------
+        const nd = uop.src.len - 1;
+        if (nd == 1) {
+            const e = try castIndex(aalloc, ptr_map, uop.src[1]);
+            try w.print("{s}", .{e});
+        } else if (nd == 2) {
+            const info = buffer_map.get(base_id) orelse return RendererError.VarMissing;
+            if (info.shape.len < 2) return RendererError.RankMismatch;
+            const cols = info.shape[info.shape.len - 1];
+            const r_exp = try castIndex(aalloc, ptr_map, uop.src[1]);
+            const c_exp = try castIndex(aalloc, ptr_map, uop.src[2]);
+            try w.print("(({s}*{d})+{s})", .{ r_exp, cols, c_exp });
+        } else {
+            return RendererError.RankMismatch;
         }
-        const index_var_id = uop.src[1];
-        index_expr_str = ptr_map.get(index_var_id) orelse return error.VariableNotFound;
-        needs_free_index_expr = false;
     }
 
-    // Determine the base pointer expression (add .ptr for slices)
-    var base_ptr_final_expr_buf: [128]u8 = undefined;
-    var base_ptr_final_expr: []const u8 = base_ptr_expr;
-    if (std.mem.startsWith(u8, base_ptr_expr, "input_") or
-        std.mem.startsWith(u8, base_ptr_expr, "output_"))
-    {
-        base_ptr_final_expr = try std.fmt.bufPrint(&base_ptr_final_expr_buf, "{s}.ptr", .{base_ptr_expr});
-    }
+    const offset_expr = try list.toOwnedSlice();
+    const dest_var = ptr_map.get(uop.id) orelse return RendererError.VarMissing;
+    const dtype_name = DTypeInfo.asString(uop.dtype);
 
-    // Declare the result address variable using the name from ptr_map
-    // Cast the index expression ({s}) to usize before multiplying by stride ({d})
-    try writer.print("const {s} = @intFromPtr({s}) + (({d}) + (@as(usize, @intCast({s}))) * {d}) * @sizeOf({s}); // GEP (uop {d})\n", .{
-        result_addr_var, // Use name from ptr_map
-        base_ptr_final_expr, // Use potentially modified expression (.ptr added)
-        offset,
-        index_expr_str, // This is the index expression (e.g., "idx_3")
-        stride,
-        type_str,
-        uop.id,
-    });
-
-    if (needs_free_index_expr) {
-        allocator.free(index_expr_str);
-    }
+    // ------------------------------------------------------------------ //
+    // 3. final pointer arithmetic                                        //
+    // ------------------------------------------------------------------ //
+    try writer.print(
+        "    const {s} = @intFromPtr({s}) + ({s})*@sizeOf({s}); // GEP id={d}\n",
+        .{ dest_var, base_ptr, offset_expr, dtype_name, uop.id },
+    );
 }

--- a/src/Core/Tensor/TensorMath/tensor_math_standard.zig
+++ b/src/Core/Tensor/TensorMath/tensor_math_standard.zig
@@ -196,7 +196,7 @@ pub const lean_matmul = op_mat_mul.lean_mat_mul;
 pub const mul = mult.mul;
 pub const mul_lean = mult.mul_lean;
 pub const get_mul_output_shape = mult.get_mul_output_shape;
-
+pub const lowerMatMul = op_mat_mul.lowerMatMul;
 //--div
 const division = @import("lib_elementWise_math/op_division.zig");
 

--- a/tests/CodeGen/renderer/lower_matmul_output_function.zig
+++ b/tests/CodeGen/renderer/lower_matmul_output_function.zig
@@ -1,0 +1,23 @@
+pub fn generated_kernel(allocator: std.mem.Allocator, input_0: []const f32, input_1: []const f32) ![]f32 {
+    const output_2 = try allocator.alloc(f32, 6);
+var idx_3: i32 = 0; // RANGE (uop 3)
+while (idx_3 < 2) : (idx_3 += 1) {
+    var idx_4: i32 = 0; // RANGE (uop 4)
+while (idx_4 < 3) : (idx_4 += 1) {
+        var acc_5: f32 = 0;
+        var idx_6: i32 = 0; // RANGE (uop 6)
+while (idx_6 < 2) : (idx_6 += 1) {
+                const addr_7 = @intFromPtr(input_0.ptr) + ((@as(usize,@intCast(idx_3))*2) + (@as(usize,@intCast(idx_6))*1))*@sizeOf(f32); // GEP id=7
+                const addr_8 = @intFromPtr(input_1.ptr) + ((@as(usize,@intCast(idx_6))*3) + (@as(usize,@intCast(idx_4))*1))*@sizeOf(f32); // GEP id=8
+                var buf_9: f32 = @as(*const f32, @ptrFromInt(addr_7)).*; // LOAD (uop 9)
+    _ = &buf_9;
+                var buf_10: f32 = @as(*const f32, @ptrFromInt(addr_8)).*; // LOAD (uop 10)
+    _ = &buf_10;
+            acc_5 += buf_9 * buf_10;
+                    }
+            const addr_13 = @intFromPtr(output_2.ptr) + (((@as(usize,@intCast(idx_3))*3)+@as(usize,@intCast(idx_4))))*@sizeOf(f32); // GEP id=13
+            @as(*f32, @ptrFromInt(addr_13)).* = acc_5; // STORE (uop 14)
+            }
+    }
+    return output_2;
+}

--- a/tests/CodeGen/renderer/lower_matmul_output_function.zig
+++ b/tests/CodeGen/renderer/lower_matmul_output_function.zig
@@ -1,23 +1,24 @@
+const std = @import("std");
 pub fn generated_kernel(allocator: std.mem.Allocator, input_0: []const f32, input_1: []const f32) ![]f32 {
     const output_2 = try allocator.alloc(f32, 6);
-var idx_3: i32 = 0; // RANGE (uop 3)
-while (idx_3 < 2) : (idx_3 += 1) {
-    var idx_4: i32 = 0; // RANGE (uop 4)
-while (idx_4 < 3) : (idx_4 += 1) {
-        var acc_5: f32 = 0;
-        var idx_6: i32 = 0; // RANGE (uop 6)
-while (idx_6 < 2) : (idx_6 += 1) {
-                const addr_7 = @intFromPtr(input_0.ptr) + ((@as(usize,@intCast(idx_3))*2) + (@as(usize,@intCast(idx_6))*1))*@sizeOf(f32); // GEP id=7
-                const addr_8 = @intFromPtr(input_1.ptr) + ((@as(usize,@intCast(idx_6))*3) + (@as(usize,@intCast(idx_4))*1))*@sizeOf(f32); // GEP id=8
+    var idx_3: i32 = 0; // RANGE (uop 3)
+    while (idx_3 < 2) : (idx_3 += 1) {
+        var idx_4: i32 = 0; // RANGE (uop 4)
+        while (idx_4 < 3) : (idx_4 += 1) {
+            var acc_5: f32 = 0;
+            var idx_6: i32 = 0; // RANGE (uop 6)
+            while (idx_6 < 2) : (idx_6 += 1) {
+                const addr_7 = @intFromPtr(input_0.ptr) + ((@as(usize, @intCast(idx_3)) * 2) + (@as(usize, @intCast(idx_6)) * 1)) * @sizeOf(f32); // GEP id=7
+                const addr_8 = @intFromPtr(input_1.ptr) + ((@as(usize, @intCast(idx_6)) * 3) + (@as(usize, @intCast(idx_4)) * 1)) * @sizeOf(f32); // GEP id=8
                 var buf_9: f32 = @as(*const f32, @ptrFromInt(addr_7)).*; // LOAD (uop 9)
-    _ = &buf_9;
+                _ = &buf_9;
                 var buf_10: f32 = @as(*const f32, @ptrFromInt(addr_8)).*; // LOAD (uop 10)
-    _ = &buf_10;
-            acc_5 += buf_9 * buf_10;
-                    }
-            const addr_13 = @intFromPtr(output_2.ptr) + (((@as(usize,@intCast(idx_3))*3)+@as(usize,@intCast(idx_4))))*@sizeOf(f32); // GEP id=13
-            @as(*f32, @ptrFromInt(addr_13)).* = acc_5; // STORE (uop 14)
+                _ = &buf_10;
+                acc_5 += buf_9 * buf_10;
             }
+            const addr_13 = @intFromPtr(output_2.ptr) + (((@as(usize, @intCast(idx_3)) * 3) + @as(usize, @intCast(idx_4)))) * @sizeOf(f32); // GEP id=13
+            @as(*f32, @ptrFromInt(addr_13)).* = acc_5; // STORE (uop 14)
+        }
     }
     return output_2;
 }

--- a/tests/CodeGen/renderer/loweradd_output_function.zig
+++ b/tests/CodeGen/renderer/loweradd_output_function.zig
@@ -1,15 +1,16 @@
+const std = @import("std");
 pub fn generated_kernel(allocator: std.mem.Allocator, input_0: []const f32, input_1: []const f32) ![]f32 {
     const output_2 = try allocator.alloc(f32, 6);
-var idx_3: i32 = 0; // RANGE (uop 3)
-while (idx_3 < 6) : (idx_3 += 1) {
-        const addr_4 = @intFromPtr(input_0.ptr) + ((((@as(usize,@intCast(idx_3))/3)*3)+((@as(usize,@intCast(idx_3))%3)*1)))*@sizeOf(f32); // GEP id=4
-        const addr_5 = @intFromPtr(input_1.ptr) + ((((@as(usize,@intCast(idx_3))/3)*0)+((@as(usize,@intCast(idx_3))%3)*1)))*@sizeOf(f32); // GEP id=5
+    var idx_3: i32 = 0; // RANGE (uop 3)
+    while (idx_3 < 6) : (idx_3 += 1) {
+        const addr_4 = @intFromPtr(input_0.ptr) + ((((@as(usize, @intCast(idx_3)) / 3) * 3) + ((@as(usize, @intCast(idx_3)) % 3) * 1))) * @sizeOf(f32); // GEP id=4
+        const addr_5 = @intFromPtr(input_1.ptr) + ((((@as(usize, @intCast(idx_3)) / 3) * 0) + ((@as(usize, @intCast(idx_3)) % 3) * 1))) * @sizeOf(f32); // GEP id=5
         var buf_6: f32 = @as(*const f32, @ptrFromInt(addr_4)).*; // LOAD (uop 6)
-    _ = &buf_6;
+        _ = &buf_6;
         var buf_7: f32 = @as(*const f32, @ptrFromInt(addr_5)).*; // LOAD (uop 7)
-    _ = &buf_7;
+        _ = &buf_7;
         const buf_8 = buf_6 + buf_7; // ADD (uop 8)
-        const addr_9 = @intFromPtr(output_2.ptr) + (@as(usize,@intCast(idx_3)))*@sizeOf(f32); // GEP id=9
+        const addr_9 = @intFromPtr(output_2.ptr) + (@as(usize, @intCast(idx_3))) * @sizeOf(f32); // GEP id=9
         @as(*f32, @ptrFromInt(addr_9)).* = buf_8; // STORE (uop 10)
     }
     return output_2;

--- a/tests/CodeGen/renderer/loweradd_output_function.zig
+++ b/tests/CodeGen/renderer/loweradd_output_function.zig
@@ -1,0 +1,16 @@
+pub fn generated_kernel(allocator: std.mem.Allocator, input_0: []const f32, input_1: []const f32) ![]f32 {
+    const output_2 = try allocator.alloc(f32, 6);
+var idx_3: i32 = 0; // RANGE (uop 3)
+while (idx_3 < 6) : (idx_3 += 1) {
+        const addr_4 = @intFromPtr(input_0.ptr) + ((((@as(usize,@intCast(idx_3))/3)*3)+((@as(usize,@intCast(idx_3))%3)*1)))*@sizeOf(f32); // GEP id=4
+        const addr_5 = @intFromPtr(input_1.ptr) + ((((@as(usize,@intCast(idx_3))/3)*0)+((@as(usize,@intCast(idx_3))%3)*1)))*@sizeOf(f32); // GEP id=5
+        var buf_6: f32 = @as(*const f32, @ptrFromInt(addr_4)).*; // LOAD (uop 6)
+    _ = &buf_6;
+        var buf_7: f32 = @as(*const f32, @ptrFromInt(addr_5)).*; // LOAD (uop 7)
+    _ = &buf_7;
+        const buf_8 = buf_6 + buf_7; // ADD (uop 8)
+        const addr_9 = @intFromPtr(output_2.ptr) + (@as(usize,@intCast(idx_3)))*@sizeOf(f32); // GEP id=9
+        @as(*f32, @ptrFromInt(addr_9)).* = buf_8; // STORE (uop 10)
+    }
+    return output_2;
+}

--- a/tests/CodeGen/renderer/test_zig_renderer.zig
+++ b/tests/CodeGen/renderer/test_zig_renderer.zig
@@ -7,11 +7,9 @@ const UOpType = zant.uops.UOpType;
 
 const ZigRenderer = Renderer.ZigRenderer;
 const lowerAdd = zant.core.tensor.math_standard.lowerAdd;
+const lowerMatMul = zant.core.tensor.math_standard.lowerMatMul;
 const UOpBuilder = zant.uops.UOpBuilder;
 const DType = zant.uops.DType;
-
-// Import the generated kernel file
-//const kernel = @import("loweradd_output_function.zig");
 
 // /* REMOVED OLD TESTS
 // test "Arithmetic operations" { ... }
@@ -65,10 +63,25 @@ test "LowerAdd Pipeline" {
     defer {
         std.debug.print("DEBUG: Freeing internal src for {d} uops in test\n", .{uops_list.len});
         for (uops_list) |uop| {
-            // Same check as in (fixed) builder deinit
+            // Free src (only if non-empty)
             if (uop.src.len > 0) {
-                // Maybe add ptr check here too if needed
                 allocator.free(@constCast(uop.src));
+            }
+            // Free duplicated arg payloads (only if non-null and relevant type)
+            if (uop.arg) |arg_val| {
+                // Use switch for type-safe union payload access
+                if (uop.op == .VIEW) {
+                    switch (arg_val) {
+                        .view_meta => |vm| {
+                            // Only free if non-empty
+                            if (vm.shape.len > 0) allocator.free(@constCast(vm.shape));
+                            if (vm.strides.len > 0) allocator.free(@constCast(vm.strides));
+                        },
+                        else => {}, // VIEW op with unexpected arg type? Ignore.
+                    }
+                }
+                // Add else if for other duplicated args
+                // else if (uop.op == .SOME_OTHER_OP) { ... }
             }
         }
     }
@@ -100,28 +113,190 @@ test "LowerAdd Pipeline" {
     // try std.fs.cwd().deleteFile(output_filename);
 }
 
-// test "Test Generated LowerAdd Kernel" {
-//     std.debug.print("Testing generated kernel from loweradd_output_function.zig\n", .{});
-//     const allocator = std.testing.allocator;
+test "LowerMatMul Pipeline" {
+    std.debug.print("Running zig renderer lowerMatMul pipeline test\n", .{});
+    const allocator = std.testing.allocator;
 
-//     // 1. Define input data
-//     // Kernel expects input_0 and input_1, both []const f32
-//     // Based on the loop (0..6), they should have 6 elements
-//     const input_data_0 = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
-//     const input_data_1 = [_]f32{ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0 };
+    // 1. Setup UOpBuilder
+    var builder = UOpBuilder.init(allocator);
+    // No defer needed if we don't take ownership of slice
 
-//     // 2. Call the generated kernel
-//     // IMPORTANT: Match the argument order from the generated function signature!
-//     // pub fn generated_kernel(allocator: std.mem.Allocator, input_1: []const f32, input_0: []const f32)
-//     const result_slice = try kernel.generated_kernel(allocator, &input_data_1, &input_data_0);
-//     defer allocator.free(result_slice); // Kernel allocates the output slice
+    // 2. Define inputs for lowerMatMul
+    const A_id: usize = 0; // Simulated input tensor ID (Matrix A)
+    const B_id: usize = 1; // Simulated input tensor ID (Matrix B)
 
-//     // 3. Define expected output
-//     // result[i] = input_0[i] + input_1[i]
-//     const expected_result = [_]f32{ 11.0, 13.0, 15.0, 17.0, 19.0, 21.0 };
+    // Example: C[M, N] = A[M, K] @ B[K, N]
+    // Let M=2, K=2, N=3
+    const M: usize = 2;
+    const K: usize = 2;
+    const N: usize = 3;
 
-//     // 4. Compare results
-//     try std.testing.expectEqualSlices(f32, &expected_result, result_slice);
+    const shapeA = &.{ M, K }; // Shape of A
+    const shapeB = &.{ K, N }; // Shape of B
+    const out_shape = &.{ M, N }; // Shape of C (output)
 
-//     std.debug.print("Generated kernel test passed!\n", .{});
-// }
+    const out_dtype = DType.f32;
+
+    // 3. Call lowerMatMul to generate UOps
+    const out_buf_id = lowerMatMul(
+        &builder,
+        A_id,
+        B_id,
+        shapeA,
+        shapeB,
+        out_shape,
+        out_dtype,
+    );
+    _ = out_buf_id; // Prevent unused warning
+
+    // Take ownership of UOps
+    const uops_list = try builder.toOwnedSlice();
+    // Deinit builder immediately as its list is now empty
+    builder.deinit();
+    // Defer freeing the main slice AFTER freeing internal src slices
+    defer allocator.free(uops_list);
+
+    // DEBUG: Print the generated UOps
+    std.debug.print("--- Generated UOps (MatMul) ---\n", .{});
+    for (uops_list) |uop| {
+        uop.dump(std.io.getStdErr().writer()) catch {}; // Dump to stderr
+    }
+    std.debug.print("-----------------------------\n", .{});
+
+    // Add defer to free duplicated src slices within the owned list
+    defer {
+        std.debug.print("DEBUG: Freeing internal src for {d} uops in MatMul test\n", .{uops_list.len});
+        for (uops_list) |uop| {
+            // Free src (only if non-empty)
+            if (uop.src.len > 0) {
+                allocator.free(@constCast(uop.src));
+            }
+            // Free duplicated arg payloads (only if non-null and relevant type)
+            if (uop.arg) |arg_val| {
+                // Use switch for type-safe union payload access
+                if (uop.op == .VIEW) {
+                    switch (arg_val) {
+                        .view_meta => |vm| {
+                            // Only free if non-empty
+                            if (vm.shape.len > 0) allocator.free(@constCast(vm.shape));
+                            if (vm.strides.len > 0) allocator.free(@constCast(vm.strides));
+                        },
+                        else => {}, // VIEW op with unexpected arg type? Ignore.
+                    }
+                }
+                // Add else if for other duplicated args
+                // else if (uop.op == .SOME_OTHER_OP) { ... }
+            }
+        }
+    }
+
+    // 4. Render UOps to Zig code as a function
+    var buffer = std.ArrayList(u8).init(allocator);
+    defer buffer.deinit();
+    const Writer = @TypeOf(buffer.writer());
+    var renderer = ZigRenderer(Writer).init(allocator, buffer.writer());
+    defer renderer.deinit(); // Deinit renderer AFTER use
+
+    // Specify which IDs are inputs
+    const input_ids = &[_]usize{ A_id, B_id };
+    try renderer.render_as_function(uops_list, input_ids); // Call the new method
+
+    const actual_code = try buffer.toOwnedSlice();
+    defer allocator.free(actual_code);
+
+    std.debug.print("\n--- Generated Function (MatMul) ---\n{s}\n---------------------------------\n", .{actual_code});
+
+    // 5. Save output to a file
+    const output_filename = "tests/CodeGen/renderer/lower_matmul_output_function.zig"; // Save inside tests dir
+    var file = try std.fs.cwd().createFile(output_filename, .{ .read = true }); // Ensure write permissions
+    defer file.close();
+    _ = try file.write(actual_code);
+    std.debug.print("Generated matmul function saved to {s}\n", .{output_filename});
+
+    // Optional: Clean up the generated file
+    // try std.fs.cwd().deleteFile(output_filename);
+}
+test "Test Generated LowerMatMul Kernel" {
+    std.debug.print("Testing generated kernel from lower_matmul_output_function.zig\n", .{});
+    const allocator = std.testing.allocator;
+    const kernel = @import("lower_matmul_output_function.zig"); // Import the generated file
+
+    // 1. Define input data (A[M, K], B[K, N])
+    const M = 2;
+    const K = 2;
+    const N = 3;
+    const input_data_0: [M * K]f32 = .{ // A: 2x2
+        1.0, 2.0, // Row 0
+        3.0, 4.0, // Row 1
+    };
+    const input_data_1: [K * N]f32 = .{ // B: 2x3
+        5.0, 6.0, 7.0, // Row 0
+        8.0, 9.0, 10.0, // Row 1
+    };
+
+    // 2. Call the generated kernel
+    const result_slice = try kernel.generated_kernel(allocator, &input_data_0, &input_data_1);
+    defer allocator.free(result_slice); // Kernel allocates the output slice (size M*N)
+
+    // 3. Define expected output C[M, N]
+    const expected_result: [M * N]f32 = .{
+        21.0, 24.0, 27.0, // Row 0
+        47.0, 54.0, 61.0, // Row 1
+    };
+
+    // 4. Compare results
+    try std.testing.expectEqualSlices(f32, &expected_result, result_slice);
+
+    std.debug.print("Generated matmul kernel test passed!\n", .{});
+}
+
+test "Test Generated LowerAdd Kernel" {
+    std.debug.print("Testing generated kernel from loweradd_output_function.zig\n", .{});
+    const allocator = std.testing.allocator;
+    // Import the generated kernel file
+    const kernel = @import("loweradd_output_function.zig");
+
+    // 1. Define input data based on LowerAdd Pipeline shapes/strides
+    // A shape {2, 3}, stride {3, 1} -> 6 elements, row-major
+    const input_data_0 = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+    // B shape {2, 3}, stride {0, 1} -> Broadcast dim 0, reads elements {10, 11, 12} repeatedly
+    // Kernel expects a slice, provide the full data based on loop access pattern.
+    // The generated kernel from LowerAdd likely loops 0..6.
+    // Based on stride {0, 1}, B[0, j] = B_data[j], B[1, j] = B_data[j]
+    // If the kernel accesses linearly (0..6), it accesses:
+    // idx 0 -> A[0,0], B[0,0] -> input_0[0], input_1[0]
+    // idx 1 -> A[0,1], B[0,1] -> input_0[1], input_1[1]
+    // idx 2 -> A[0,2], B[0,2] -> input_0[2], input_1[2]
+    // idx 3 -> A[1,0], B[1,0] -> input_0[3], input_1[0]  <-- B repeats
+    // idx 4 -> A[1,1], B[1,1] -> input_0[4], input_1[1]  <-- B repeats
+    // idx 5 -> A[1,2], B[1,2] -> input_0[5], input_1[2]  <-- B repeats
+    // So input_1 needs to contain {10, 11, 12} for the generated loop accesses.
+    // However, the generated code *might* pass the full slice. Let's assume it takes the broadcasted view:
+    const input_data_1 = [_]f32{ 10.0, 11.0, 12.0 }; // Only the unique values due to broadcast stride {0,1}
+    // IMPORTANT: The generated kernel likely accesses input_1 linearly based on the RANGE(0..6)
+    // It will calculate addresses based on strides {3,1} for input_0 and {0,1} for input_1
+    // GEP input_0 (View strides {3,1}): (idx_3 / 3) * 3 + (idx_3 % 3) * 1 = idx_3
+    // GEP input_1 (View strides {0,1}): (idx_3 / 3) * 0 + (idx_3 % 3) * 1 = idx_3 % 3
+    // So, input_1 needs 3 elements, accessed via index % 3.
+
+    // 2. Call the generated kernel
+    // Signature: pub fn generated_kernel(allocator: std.mem.Allocator, input_0: []const f32, input_1: []const f32) ![]f32
+    const result_slice = try kernel.generated_kernel(allocator, &input_data_0, &input_data_1);
+    defer allocator.free(result_slice); // Kernel allocates the output slice (size 6)
+
+    // 3. Define expected output
+    // C[i] = A[i] + B[i % 3]
+    const expected_result = [_]f32{
+        1.0 + 10.0, // 11.0
+        2.0 + 11.0, // 13.0
+        3.0 + 12.0, // 15.0
+        4.0 + 10.0, // 14.0
+        5.0 + 11.0, // 16.0
+        6.0 + 12.0, // 18.0
+    };
+
+    // 4. Compare results
+    try std.testing.expectEqualSlices(f32, &expected_result, result_slice);
+
+    std.debug.print("Generated LowerAdd kernel test passed!\n", .{});
+}


### PR DESCRIPTION

---

# Pull Request Template

## Description

This PR rewrites the Zig renderer to support full IR-to-Zig lowering.
It enables rendering a full `generated_kernel` function from a list of `UOp`s, supporting VIEW, GEP, arithmetic ops, LOAD/STORE, and accumulators.
Memory safety is ensured via proper duplication and deallocation of all heap-allocated metadata.



## Type of Change

* [x] New feature 🚀
* [x] Bug fix 🐛
* [x] Documentation update 📚

## Checklist

* [x] Code follows style guidelines
* [x] Self-reviewed
* [x] Docs added (`docs/renderer_deep_dive.md`)
* [x] Tests added and passing

## Testing

Ran:

* `zig build test` – all tests pass (Add, ReduceMean, MatMul)
* Verified VIEW/GEP pointer math correctness and memory deallocation

## Additional Information

This unlocks implementation of future UOps (REDUCE, PAD, etc.) through isolated renderer modules.
