### PR TITLE
Refactor CMSIS-NN integration and document CI performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
   <img src="https://github.com/ZIGTinyBook/Z-Ant/actions/workflows/zig-codegen-tests.yml/badge.svg" alt="Zig Codegen Tests" />
 </div>
 
+![image](https://github.com/user-attachments/assets/6a5346e5-58ec-4069-8143-c3b7b03586f3)
+
+## 🛠️ CI/CD
+
+- `zig-tests` – regression suite covering the core runtime.
+- `zig-codegen-tests` – validates generated operators and glue code.
+- `zant-benchmarks` – runs the Beer end-to-end benchmark and refreshes the metrics below.
+
+### 📈 Performance Snapshot
 <!-- BEER_TIMINGS_START -->
 Beer model timing (QEMU, Cortex-M55):
 
@@ -13,9 +22,6 @@ Beer model timing (QEMU, Cortex-M55):
 - CMSIS-NN: 1353.59 ms
 - Improvement: 2118.77 ms (61.0%)
 <!-- BEER_TIMINGS_END -->
-
-
-![image](https://github.com/user-attachments/assets/6a5346e5-58ec-4069-8143-c3b7b03586f3)
 
 
 ## Project Overview

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
   <img src="https://github.com/ZIGTinyBook/Z-Ant/actions/workflows/zig-codegen-tests.yml/badge.svg" alt="Zig Codegen Tests" />
 </div>
 
+<!-- BEER_TIMINGS_START -->
+Beer model timing (QEMU, Cortex-M55):
+
+- Reference: 1125.42 ms
+- CMSIS-NN: 1001.41 ms
+- Improvement: 124.01 ms (11.0%)
+<!-- BEER_TIMINGS_END -->
+
 ![image](https://github.com/user-attachments/assets/6a5346e5-58ec-4069-8143-c3b7b03586f3)
 
 ## 🛠️ CI/CD
@@ -15,13 +23,6 @@
 - `zant-benchmarks` – runs the Beer end-to-end benchmark and refreshes the metrics below.
 
 ### 📈 Performance Snapshot
-<!-- BEER_TIMINGS_START -->
-Beer model timing (QEMU, Cortex-M55):
-
-- Reference: 3472.36 ms
-- CMSIS-NN: 1353.59 ms
-- Improvement: 2118.77 ms (61.0%)
-<!-- BEER_TIMINGS_END -->
 
 
 ## Project Overview

--- a/build.zig
+++ b/build.zig
@@ -245,6 +245,7 @@ pub fn build(b: *std.Build) void {
 
     const IR_zant_mod = b.createModule(.{ .root_source_file = b.path("src/IR_zant/IR_zant.zig") });
     IR_zant_mod.addImport("zant", zant_mod);
+    IR_zant_mod.addOptions("build_options", build_options);
 
     const codegen_mod = b.createModule(.{ .root_source_file = b.path("src/codegen/codegen.zig") });
     codegen_mod.addImport("zant", zant_mod);

--- a/build.zig
+++ b/build.zig
@@ -245,7 +245,6 @@ pub fn build(b: *std.Build) void {
 
     const IR_zant_mod = b.createModule(.{ .root_source_file = b.path("src/IR_zant/IR_zant.zig") });
     IR_zant_mod.addImport("zant", zant_mod);
-    IR_zant_mod.addOptions("build_options", build_options);
 
     const codegen_mod = b.createModule(.{ .root_source_file = b.path("src/codegen/codegen.zig") });
     codegen_mod.addImport("zant", zant_mod);

--- a/src/Core/Tensor/Accelerators/mod.zig
+++ b/src/Core/Tensor/Accelerators/mod.zig
@@ -32,6 +32,10 @@ pub fn isEthosRequested() bool {
     return @hasDecl(build_options, "stm32n6_use_ethos") and build_options.stm32n6_use_ethos;
 }
 
+pub fn canUseCmsisHelium() bool {
+    return isStm32n6Enabled() and !isForceNativeEnabled() and isCmsisRequested();
+}
+
 pub fn tryConvLean(
     comptime T: type,
     input: *const TensorModule.Tensor(T),

--- a/src/Core/Tensor/Accelerators/stm32n6/cmsis_nn.zig
+++ b/src/Core/Tensor/Accelerators/stm32n6/cmsis_nn.zig
@@ -1,8 +1,10 @@
 const build_options = @import("build_options");
 
 /// Indicates whether CMSIS Helium kernels are enabled for the current build.
-pub const is_enabled =
-    @hasDecl(build_options, "stm32n6_use_cmsis") and build_options.stm32n6_use_cmsis;
+const accel_requested = @hasDecl(build_options, "stm32n6_accel") and build_options.stm32n6_accel;
+const cmsis_requested = @hasDecl(build_options, "stm32n6_use_cmsis") and build_options.stm32n6_use_cmsis;
+const force_native = @hasDecl(build_options, "stm32n6_force_native") and build_options.stm32n6_force_native;
+pub const is_enabled = accel_requested and cmsis_requested and !force_native;
 
 /// Common CMSIS-NN structures mirrored from the C headers.
 /// Keeping them in a shared module makes it easier to add new Helium bindings

--- a/src/Core/Tensor/Accelerators/stm32n6/cmsis_nn.zig
+++ b/src/Core/Tensor/Accelerators/stm32n6/cmsis_nn.zig
@@ -1,0 +1,108 @@
+const build_options = @import("build_options");
+
+/// Indicates whether CMSIS Helium kernels are enabled for the current build.
+pub const is_enabled =
+    @hasDecl(build_options, "stm32n6_use_cmsis") and build_options.stm32n6_use_cmsis;
+
+/// Common CMSIS-NN structures mirrored from the C headers.
+/// Keeping them in a shared module makes it easier to add new Helium bindings
+/// without copy/pasting the extern declarations across operators.
+pub const Dims = extern struct {
+    n: i32,
+    h: i32,
+    w: i32,
+    c: i32,
+};
+
+pub const Context = extern struct {
+    buf: ?*anyopaque,
+    size: i32,
+};
+
+pub const ConvParams = extern struct {
+    input_offset: i32,
+    output_offset: i32,
+    stride: extern struct { h: i32, w: i32 },
+    padding: extern struct { h: i32, w: i32 },
+    dilation: extern struct { h: i32, w: i32 },
+    activation: extern struct { min: i32, max: i32 },
+};
+
+pub const PerChannelQuantParams = extern struct {
+    multiplier: [*]i32,
+    shift: [*]i32,
+};
+
+/// CMSIS-NN status codes shared across the accelerator bindings.
+pub const ARM_CMSIS_NN_SUCCESS: i32 = 0;
+
+/// Namespace exposing the CMSIS-NN entry points we rely on. When Helium support
+/// is disabled at build time the functions degrade to inert stubs so that the
+/// call sites automatically fall back to the portable implementations.
+pub const functions = if (is_enabled) struct {
+    extern fn arm_convolve_s8_get_buffer_size(
+        input_dims: *const Dims,
+        filter_dims: *const Dims,
+    ) callconv(.C) i32;
+
+    extern fn arm_convolve_s8(
+        ctx: *const Context,
+        conv_params: *const ConvParams,
+        quant_params: *const PerChannelQuantParams,
+        input_dims: *const Dims,
+        input_data: [*]const i8,
+        filter_dims: *const Dims,
+        filter_data: [*]const i8,
+        bias_dims: *const Dims,
+        bias_data: ?[*]const i32,
+        upscale_dims: ?*const Dims,
+        output_dims: *const Dims,
+        output_data: [*]i8,
+    ) callconv(.C) i32;
+} else struct {
+    pub fn arm_convolve_s8_get_buffer_size(
+        input_dims: *const Dims,
+        filter_dims: *const Dims,
+    ) callconv(.C) i32 {
+        _ = input_dims;
+        _ = filter_dims;
+        return 0;
+    }
+
+    pub fn arm_convolve_s8(
+        ctx: *const Context,
+        conv_params: *const ConvParams,
+        quant_params: *const PerChannelQuantParams,
+        input_dims: *const Dims,
+        input_data: [*]const i8,
+        filter_dims: *const Dims,
+        filter_data: [*]const i8,
+        bias_dims: *const Dims,
+        bias_data: ?[*]const i32,
+        upscale_dims: ?*const Dims,
+        output_dims: *const Dims,
+        output_data: [*]i8,
+    ) callconv(.C) i32 {
+        _ = ctx;
+        _ = conv_params;
+        _ = quant_params;
+        _ = input_dims;
+        _ = input_data;
+        _ = filter_dims;
+        _ = filter_data;
+        _ = bias_dims;
+        _ = bias_data;
+        _ = upscale_dims;
+        _ = output_dims;
+        _ = output_data;
+        return 0;
+    }
+};
+
+/// Helper queried by the TensorMath layer to understand if a Helium
+/// implementation for QLinearConv can be attempted. Extend this (or add new
+/// helpers) when wiring additional CMSIS-NN kernels such as MaxPool.
+pub inline fn supportsConvolveS8() bool {
+    return is_enabled;
+}
+

--- a/src/Core/Tensor/TensorMath/op_qlinearconv_simd.zig
+++ b/src/Core/Tensor/TensorMath/op_qlinearconv_simd.zig
@@ -283,7 +283,7 @@ fn tryAcceleratedQLinearConv(
     groups: usize,
     auto_pad: []const u8,
 ) bool {
-    if (!accelerators.isStm32n6Enabled()) return false;
+    if (!accelerators.canUseCmsisHelium()) return false;
 
     // Try direct CMSIS-NN quantized convolution first
     if (tryDirectCmsisNnQLinearConv(InputType, WeightType, OutputType, BiasType, x, x_scale_f, x_zp, w, w_scale, w_zero_point, output, y_scale_f, y_zp, bias, stride_h, stride_w, pad_top, pad_left, pad_bottom, pad_right, dilation_h, dilation_w, groups, auto_pad)) {

--- a/src/Core/Tensor/TensorMath/op_qlinearconv_simd.zig
+++ b/src/Core/Tensor/TensorMath/op_qlinearconv_simd.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const Tensor = @import("../tensor.zig").Tensor;
 const TensorMathError = @import("../../../Utils/errorHandler.zig").TensorMathError;
 const accelerators = @import("../Accelerators/mod.zig");
-const conv_math = @import("op_convolution.zig");
+const cmsis_nn = @import("../Accelerators/stm32n6/cmsis_nn.zig");
 
 const accel_scratch_size = 1024 * 1024;
 var accel_scratch: [accel_scratch_size]u8 linksection(".tensor_pool") = undefined;
@@ -77,102 +77,13 @@ inline fn get_channel_zero_point(tensor: anytype, channel: usize) i32 {
     return @as(i32, @intCast(tensor.data[idx]));
 }
 
-// CMSIS-NN external function declarations (will link correctly when CMSIS-NN sources are included)
-
-// CMSIS-NN structures (matching the C headers)
-const cmsis_nn_dims = extern struct {
-    n: i32,
-    h: i32,
-    w: i32,
-    c: i32,
-};
-
-const cmsis_nn_context = extern struct {
-    buf: ?*anyopaque,
-    size: i32,
-};
-
-const cmsis_nn_conv_params = extern struct {
-    input_offset: i32,
-    output_offset: i32,
-    stride: extern struct { h: i32, w: i32 },
-    padding: extern struct { h: i32, w: i32 },
-    dilation: extern struct { h: i32, w: i32 },
-    activation: extern struct { min: i32, max: i32 },
-};
-
-const cmsis_nn_per_channel_quant_params = extern struct {
-    multiplier: [*]i32,
-    shift: [*]i32,
-};
-
-// External CMSIS-NN function declarations (only when CMSIS is enabled)
-const build_options = @import("build_options");
-const use_cmsis = @hasDecl(build_options, "stm32n6_use_cmsis") and build_options.stm32n6_use_cmsis;
-
-const cmsis_nn_functions = if (use_cmsis) struct {
-    extern fn arm_convolve_s8_get_buffer_size(
-        input_dims: *const cmsis_nn_dims,
-        filter_dims: *const cmsis_nn_dims,
-    ) callconv(.C) i32;
-
-    extern fn arm_convolve_s8(
-        ctx: *const cmsis_nn_context,
-        conv_params: *const cmsis_nn_conv_params,
-        quant_params: *const cmsis_nn_per_channel_quant_params,
-        input_dims: *const cmsis_nn_dims,
-        input_data: [*]const i8,
-        filter_dims: *const cmsis_nn_dims,
-        filter_data: [*]const i8,
-        bias_dims: *const cmsis_nn_dims,
-        bias_data: ?[*]const i32,
-        upscale_dims: ?*const cmsis_nn_dims,
-        output_dims: *const cmsis_nn_dims,
-        output_data: [*]i8,
-    ) callconv(.C) i32;
-} else struct {
-    // Dummy functions when CMSIS is not enabled
-    fn arm_convolve_s8_get_buffer_size(
-        input_dims: *const cmsis_nn_dims,
-        filter_dims: *const cmsis_nn_dims,
-    ) callconv(.C) i32 {
-        _ = input_dims;
-        _ = filter_dims;
-        return 0;
-    }
-
-    fn arm_convolve_s8(
-        ctx: *const cmsis_nn_context,
-        conv_params: *const cmsis_nn_conv_params,
-        quant_params: *const cmsis_nn_per_channel_quant_params,
-        input_dims: *const cmsis_nn_dims,
-        input_data: [*]const i8,
-        filter_dims: *const cmsis_nn_dims,
-        filter_data: [*]const i8,
-        bias_dims: *const cmsis_nn_dims,
-        bias_data: ?[*]const i32,
-        upscale_dims: ?*const cmsis_nn_dims,
-        output_dims: *const cmsis_nn_dims,
-        output_data: [*]i8,
-    ) callconv(.C) i32 {
-        _ = ctx;
-        _ = conv_params;
-        _ = quant_params;
-        _ = input_dims;
-        _ = input_data;
-        _ = filter_dims;
-        _ = filter_data;
-        _ = bias_dims;
-        _ = bias_data;
-        _ = upscale_dims;
-        _ = output_dims;
-        _ = output_data;
-        return 0;
-    }
-};
-
-// CMSIS-NN constants
-const ARM_CMSIS_NN_SUCCESS: i32 = 0;
+// CMSIS-NN extern definitions are centralized in the STM32N6 accelerator
+// module so they can be reused by future Helium-accelerated operators.
+const cmsis_nn_dims = cmsis_nn.Dims;
+const cmsis_nn_context = cmsis_nn.Context;
+const cmsis_nn_conv_params = cmsis_nn.ConvParams;
+const cmsis_nn_per_channel_quant_params = cmsis_nn.PerChannelQuantParams;
+const cmsis_nn_functions = cmsis_nn.functions;
 
 fn tryDirectCmsisNnQLinearConv(
     comptime InputType: type,
@@ -201,7 +112,8 @@ fn tryDirectCmsisNnQLinearConv(
     auto_pad: []const u8,
 ) bool {
     // Only proceed when STM32N6 acceleration is enabled (where CMSIS-NN sources will be linked)
-    if (!accelerators.isStm32n6Enabled()) return false;
+    if (!accelerators.canUseCmsisHelium()) return false;
+    if (!cmsis_nn.supportsConvolveS8()) return false;
 
     _ = auto_pad;
     _ = w_zero_point; // TODO: implement per-channel weight zero points
@@ -342,7 +254,7 @@ fn tryDirectCmsisNnQLinearConv(
         @as([*]i8, @ptrCast(output.data.ptr)),
     );
 
-    return result == ARM_CMSIS_NN_SUCCESS;
+    return result == cmsis_nn.ARM_CMSIS_NN_SUCCESS;
 }
 
 fn tryAcceleratedQLinearConv(

--- a/src/IR_zant/op_union/operators/op_qlinearconv.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearconv.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const allocator = std.heap.page_allocator;
 const zant = @import("zant");
 const IR_zant = @import("../../IR_zant.zig");
-const build_options = @import("build_options");
+const accelerators = zant.core.tensor.accelerators;
 
 // --- onnx ---
 const onnx = zant.onnx;
@@ -21,12 +21,7 @@ const NodeZant = NodeZant_lib.NodeZant;
 const tensorMath = zant.core.tensor.math_standard;
 const utils = IR_zant.utils;
 
-const cmsis_codegen_enabled = blk: {
-    const accel_requested = @hasDecl(build_options, "stm32n6_accel") and build_options.stm32n6_accel;
-    const cmsis_requested = @hasDecl(build_options, "stm32n6_use_cmsis") and build_options.stm32n6_use_cmsis;
-    const forced_native = @hasDecl(build_options, "stm32n6_force_native") and build_options.stm32n6_force_native;
-    break :blk accel_requested and cmsis_requested and !forced_native;
-};
+const cmsis_codegen_enabled = accelerators.canUseCmsisHelium();
 
 // https://onnx.ai/onnx/operators/onnx__QLinearConv.html
 // INPUTS:

--- a/src/IR_zant/op_union/operators/op_qlinearconv.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearconv.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const allocator = std.heap.page_allocator;
 const zant = @import("zant");
 const IR_zant = @import("../../IR_zant.zig");
+const build_options = @import("build_options");
 
 // --- onnx ---
 const onnx = zant.onnx;
@@ -19,6 +20,13 @@ const NodeZant = NodeZant_lib.NodeZant;
 
 const tensorMath = zant.core.tensor.math_standard;
 const utils = IR_zant.utils;
+
+const cmsis_codegen_enabled = blk: {
+    const accel_requested = @hasDecl(build_options, "stm32n6_accel") and build_options.stm32n6_accel;
+    const cmsis_requested = @hasDecl(build_options, "stm32n6_use_cmsis") and build_options.stm32n6_use_cmsis;
+    const forced_native = @hasDecl(build_options, "stm32n6_force_native") and build_options.stm32n6_force_native;
+    break :blk accel_requested and cmsis_requested and !forced_native;
+};
 
 // https://onnx.ai/onnx/operators/onnx__QLinearConv.html
 // INPUTS:
@@ -257,9 +265,10 @@ pub const QLinearConv = struct {
         // Determine the bias type
         const bias_type = if (self.input_B) |bias_tensor| bias_tensor.ty.toString() else "f32";
 
-        // Generate the function call - use SIMD optimized version for maximum performance
+        // Generate the function call - prefer CMSIS Helium when it is part of the build, otherwise fall back to the embedded-friendly path
+        const qlinearconv_impl = if (cmsis_codegen_enabled) "qlinearconv_simd_lean" else "qlinearconv_embedded_lean";
         try writer.print(
-            \\    tensMath.qlinearconv_simd_lean(
+            \\    tensMath.{s}(
             \\        {s}, // InputType
             \\        {s}, // WeightType
             \\        {s}, // ScaleType
@@ -282,6 +291,7 @@ pub const QLinearConv = struct {
             \\        "{s}", // auto_pad
             \\    ) catch return -1;
         , .{
+            qlinearconv_impl,
             target_type, // InputType
             self.input_w.ty.toString(), // WeightType (use actual weight type)
             "f32", // ScaleType (scales are always f32)


### PR DESCRIPTION
## Summary
- Extracted the CMSIS-NN type and function declarations into a reusable STM32N6 helper so additional Helium kernels can plug in without duplicating FFI glue.
- Added an accelerator helper that prevents CMSIS-NN from being selected when the STM32N6 backend is forced into native emulation and updated the quantized convolution path to honour it.
- Documented the active CI/CD workflows in the README and moved the Beer benchmark performance snapshot directly under the project logo.
- Updated QLinearConv code generation to fall back to the embedded lean implementation whenever CMSIS Helium support is not enabled so non-CMSIS builds avoid the SIMD shim.
