### PR TITLE
Enable in-place clip aliasing in execution plan

### DIFF
--- a/src/codegen/cg_v1/predict/emit.zig
+++ b/src/codegen/cg_v1/predict/emit.zig
@@ -95,10 +95,20 @@ pub const PlanEmitter = struct {
                 try emitTensorAllocation(writer, &tensor, dynamic);
             }
 
+            // Emit aliases for in-place operations
+            for (step.aliases.items) |tensor| {
+                if (tensor.alias_of) |base_name| {
+                    const alias_name = sanitizeName(tensor.name);
+                    const base_alias = sanitizeName(base_name);
+                    try writer.print("    // In-place alias: {s} -> {s}\n", .{ alias_name, base_alias });
+                    try writer.print("    var tensor_{s} = tensor_{s};\n", .{ alias_name, base_alias });
+                }
+            }
+
             // Comment with operation info
             try writer.print(
                 \\
-                \\   // Step {d}: {s} operation
+               \\   // Step {d}: {s} operation
                 \\
             , .{ step_idx, sanitizeName(step.node.*.op_type) });
 

--- a/src/codegen/cg_v1/predict/plan.zig
+++ b/src/codegen/cg_v1/predict/plan.zig
@@ -17,16 +17,18 @@ pub const PlanTensor = struct {
     // Liveness information
     first_def_step: ?usize = null, // First step where tensor is defined/written
     last_use_step: ?usize = null, // Last step where tensor is used/read
+    alias_of: ?[]const u8 = null, // Canonical tensor name if this tensor is an in-place alias
 
     /// Returns true if this tensor should be allocated at the given step
     pub fn shouldAllocateAt(self: *const PlanTensor, step: usize) bool {
+        if (self.alias_of != null) return false;
         return self.first_def_step == step and
             (self.category == .LINK or self.category == .OUTPUT);
     }
 
     /// Returns true if this tensor should be deallocated after the given step
     pub fn shouldDeallocateAfter(self: *const PlanTensor, step: usize) bool {
-        return self.last_use_step == step and self.category == .LINK;
+        return self.alias_of == null and self.last_use_step == step and self.category == .LINK;
     }
 };
 
@@ -41,9 +43,13 @@ pub const PlanStep = struct {
     // Tensors to deallocate after this step
     frees: std.ArrayList(PlanTensor),
 
+    // Tensors that alias previously allocated buffers (in-place ops)
+    aliases: std.ArrayList(PlanTensor),
+
     pub fn deinit(self: *PlanStep) void {
         self.allocs.deinit();
         self.frees.deinit();
+        self.aliases.deinit();
     }
 };
 
@@ -83,6 +89,9 @@ pub fn buildExecutionPlan(allocator: std.mem.Allocator, linearizedGraph: std.Arr
     defer tensor_liveness.deinit();
 
     try computeLiveness(&tensor_liveness, linearizedGraph);
+
+    // Step 1.5: Detect in-place opportunities (alias tensors)
+    applyInPlaceOptimizations(&tensor_liveness, linearizedGraph);
 
     // Step 2: Build steps with allocation info
     try buildSteps(&plan, &tensor_liveness, linearizedGraph);
@@ -139,12 +148,17 @@ fn buildSteps(plan: *ExecutionPlan, tensor_liveness: *std.StringHashMap(PlanTens
             .node = node,
             .allocs = std.ArrayList(PlanTensor).init(plan.allocator),
             .frees = std.ArrayList(PlanTensor).init(plan.allocator),
+            .aliases = std.ArrayList(PlanTensor).init(plan.allocator),
         };
 
         // Find tensors to allocate before this step
         var iter = tensor_liveness.iterator();
         while (iter.next()) |entry| {
             const tensor = entry.value_ptr.*;
+
+            if (tensor.first_def_step == step_idx and tensor.alias_of != null) {
+                try step.aliases.append(tensor);
+            }
 
             if (tensor.shouldAllocateAt(step_idx)) {
                 try step.allocs.append(tensor);
@@ -156,5 +170,72 @@ fn buildSteps(plan: *ExecutionPlan, tensor_liveness: *std.StringHashMap(PlanTens
         }
 
         try plan.steps.append(step);
+    }
+}
+
+fn applyInPlaceOptimizations(
+    tensor_liveness: *std.StringHashMap(PlanTensor),
+    linearizedGraph: std.ArrayList(*NodeZant),
+) void {
+    for (linearizedGraph.items, 0..) |node, step_idx| {
+        switch (node.op) {
+            .clip => |clip_op| {
+                tryApplyClipInPlace(tensor_liveness, clip_op, step_idx);
+            },
+            else => {},
+        }
+    }
+}
+
+fn tryApplyClipInPlace(
+    tensor_liveness: *std.StringHashMap(PlanTensor),
+    clip_op: IR_zant.operators.Clip,
+    step_idx: usize,
+) void {
+    // Only consider LINK tensors to avoid mutating graph inputs/initializers
+    if (clip_op.input.tc != .LINK or clip_op.output.tc != .LINK) return;
+
+    // Input and output must share type and shape
+    if (clip_op.input.ty != clip_op.output.ty) return;
+    const in_shape = clip_op.input.getShape();
+    const out_shape = clip_op.output.getShape();
+    if (in_shape.len != out_shape.len) return;
+    if (!std.mem.eql(usize, in_shape, out_shape)) return;
+
+    const input_plan = tensor_liveness.getPtr(clip_op.input.name) orelse return;
+    const output_plan = tensor_liveness.getPtr(clip_op.output.name) orelse return;
+
+    if (output_plan.alias_of != null) return; // Already aliased
+
+    // Safe in-place only when this node is the final consumer of the input buffer
+    if (input_plan.last_use_step == null or input_plan.last_use_step.? != step_idx) return;
+
+    output_plan.alias_of = input_plan.name;
+
+    // Extend the lifetime of the underlying buffer to cover the alias usage
+    const new_last = output_plan.last_use_step orelse step_idx;
+    extendAliasChainLastUse(tensor_liveness, input_plan.name, new_last);
+}
+
+fn extendAliasChainLastUse(
+    tensor_liveness: *std.StringHashMap(PlanTensor),
+    tensor_name: []const u8,
+    new_last: usize,
+) void {
+    var current_name = tensor_name;
+    while (tensor_liveness.getPtr(current_name)) |plan_tensor| {
+        if (plan_tensor.last_use_step) |*last| {
+            if (new_last > last.*) {
+                last.* = new_last;
+            }
+        } else {
+            plan_tensor.last_use_step = new_last;
+        }
+
+        if (plan_tensor.alias_of) |base_name| {
+            current_name = base_name;
+        } else {
+            break;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend the execution plan data structures to track tensors that alias previously allocated buffers
- detect safe in-place opportunities for Clip nodes and mark the output as an alias of its input when exclusive ownership is guaranteed
- emit alias bindings in the plan-based code generator so in-place Clip writes reuse the original tensor storage

## Testing
- not run (zig toolchain is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d0917826088326a74d83616def0847