### PR TITLE
Return float32 from QLinearGlobalAveragePool

### DIFF
--- a/src/Core/Tensor/TensorMath/op_qlinearglobalaveragepool.zig
+++ b/src/Core/Tensor/TensorMath/op_qlinearglobalaveragepool.zig
@@ -1,13 +1,18 @@
-const std = @import("std");
 const zant = @import("../../../zant.zig");
 
 const Tensor = zant.core.tensor.Tensor;
 const pkg_allocator = zant.utils.allocator.allocator;
 const TensorMathError = zant.utils.error_handler.TensorMathError;
-const TensorError = zant.utils.error_handler.TensorError;
-
-// Import existing global average pool operation for shape calculation
-const globalAvgPool = @import("op_globalAveragePool.zig");
+// helper used to convert quantized values to floating point
+fn toF32(comptime T: type, value: T) f32 {
+    return switch (@typeInfo(T)) {
+        .Float => @as(f32, @floatCast(value)),
+        .ComptimeFloat => @floatCast(f32, value),
+        .Int => @as(f32, @floatFromInt(value)),
+        .ComptimeInt => @as(f32, @floatFromInt(value)),
+        else => @compileError("QLinearGlobalAveragePool supports only numeric element types"),
+    };
+}
 
 /// QLinearGlobalAveragePool operation following ONNX specification
 /// Performs quantized global average pooling using linear quantization scheme
@@ -20,9 +25,9 @@ const globalAvgPool = @import("op_globalAveragePool.zig");
 /// - y_zero_point: zero point for output quantization
 ///
 /// OUTPUT:
-/// - y: quantized output tensor of shape (N, C, 1, 1, ...)
+/// - y: floating point output tensor of shape (N, C, 1, 1, ...)
 ///
-/// Formula: quantized_output = quantize(global_average_pool(dequantize(x)), y_scale, y_zero_point)
+/// Formula: output = global_average_pool(dequantize(x))
 pub fn qlinearglobalaveragepool(
     comptime InputType: anytype,
     comptime ScaleType: anytype,
@@ -32,7 +37,7 @@ pub fn qlinearglobalaveragepool(
     x_zero_point: *const Tensor(ZeroPointType),
     y_scale: *const Tensor(ScaleType),
     y_zero_point: *const Tensor(ZeroPointType),
-) !Tensor(InputType) {
+) !Tensor(f32) {
     // Input validation
     if (x.shape.len < 2) {
         return TensorMathError.InvalidDimensions;
@@ -49,20 +54,17 @@ pub fn qlinearglobalaveragepool(
     defer pkg_allocator.free(output_shape);
 
     // Create output tensor
-    var output = try Tensor(InputType).fromShape(&pkg_allocator, output_shape);
+    var output = try Tensor(f32).fromShape(&pkg_allocator, output_shape);
     errdefer output.deinit();
 
     // Perform quantized global average pooling
     try lean_qlinearglobalaveragepool(
-        InputType,
-        ScaleType,
-        ZeroPointType,
         x,
         x_scale,
         x_zero_point,
+        &output,
         y_scale,
         y_zero_point,
-        &output,
     );
 
     return output;
@@ -77,10 +79,37 @@ pub fn lean_qlinearglobalaveragepool(
     y_scale: anytype,
     y_zero_point: anytype,
 ) !void {
-    const x_scale_val = x_scale.data[0];
-    const x_zero_point_val = x_zero_point.data[0];
-    const y_scale_val = y_scale.data[0];
-    const y_zero_point_val = y_zero_point.data[0];
+    comptime {
+        const output_info = @typeInfo(@TypeOf(output));
+        if (output_info != .Pointer or output_info.Pointer.child != Tensor(f32)) {
+            @compileError("QLinearGlobalAveragePool lean implementation requires a Tensor(f32) output");
+        }
+    }
+
+    const out_tensor: *Tensor(f32) = output;
+
+    if (x.shape.len < 2) {
+        return TensorMathError.InvalidDimensions;
+    }
+
+    if (out_tensor.shape.len != x.shape.len) {
+        return TensorMathError.ShapeMismatch;
+    }
+
+    if (out_tensor.shape[0] != x.shape[0] or out_tensor.shape[1] != x.shape[1]) {
+        return TensorMathError.ShapeMismatch;
+    }
+
+    for (2..out_tensor.shape.len) |i| {
+        if (out_tensor.shape[i] != 1) {
+            return TensorMathError.ShapeMismatch;
+        }
+    }
+
+    const x_scale_val = toF32(@TypeOf(x_scale.data[0]), x_scale.data[0]);
+    const x_zero_point_val = toF32(@TypeOf(x_zero_point.data[0]), x_zero_point.data[0]);
+    const _ = toF32(@TypeOf(y_scale.data[0]), y_scale.data[0]);
+    const _ = toF32(@TypeOf(y_zero_point.data[0]), y_zero_point.data[0]);
 
     // Handle different tensor dimensions
     const batch_size = if (x.shape.len >= 1) x.shape[0] else 1;
@@ -88,19 +117,11 @@ pub fn lean_qlinearglobalaveragepool(
 
     // Calculate spatial size based on tensor dimensions
     var spatial_size: usize = 1;
-    if (x.shape.len >= 3) {
-        // For 4D tensors (NCHW format): [N, C, H, W] - spatial dims are H, W
-        // For 3D tensors (CHW format): [C, H, W] - spatial dims are H, W
-        for (2..x.shape.len) |i| {
-            spatial_size *= x.shape[i];
-        }
-    } else if (x.shape.len == 2) {
-        // For 2D tensors: treat as [N, C] - no spatial dimensions
-        spatial_size = 1;
-    } else if (x.shape.len == 1) {
-        // For 1D tensors: treat as [C] - no batch or spatial dimensions
-        spatial_size = 1;
+    for (2..x.shape.len) |i| {
+        spatial_size *= x.shape[i];
     }
+
+    if (spatial_size == 0) spatial_size = 1;
 
     // Process each batch and channel
     for (0..batch_size) |n| {
@@ -109,28 +130,13 @@ pub fn lean_qlinearglobalaveragepool(
 
             // Sum all spatial elements for this channel
             // Different indexing based on tensor dimensions
-            if (x.shape.len == 1) {
-                // For 1D tensors: just use the single element
-                const input_idx = 0;
-                const InputType = @TypeOf(x.data[0]);
-                const dequant_val = if (@typeInfo(InputType) == .int)
-                    (@as(f32, @floatFromInt(x.data[input_idx])) - @as(f32, @floatFromInt(x_zero_point_val))) * x_scale_val
-                else
-                    (x.data[input_idx] - @as(InputType, @floatFromInt(x_zero_point_val))) * x_scale_val;
-                sum += @as(f64, dequant_val);
-            } else {
-                // For multi-dimensional tensors
-                const channel_start = ((n * channels) + c) * spatial_size;
-                for (0..spatial_size) |i| {
-                    const input_idx = channel_start + i;
-                    // Dequantize each input value and accumulate
-                    const InputType = @TypeOf(x.data[0]);
-                    const dequant_val = if (@typeInfo(InputType) == .int)
-                        (@as(f32, @floatFromInt(x.data[input_idx])) - @as(f32, @floatFromInt(x_zero_point_val))) * x_scale_val
-                    else
-                        (x.data[input_idx] - @as(InputType, @floatFromInt(x_zero_point_val))) * x_scale_val;
-                    sum += @as(f64, dequant_val);
-                }
+            const channel_start = ((n * channels) + c) * spatial_size;
+            for (0..spatial_size) |i| {
+                const input_idx = channel_start + i;
+                const InputElemType = @TypeOf(x.data[0]);
+                const input_val = toF32(InputElemType, x.data[input_idx]);
+                const dequant_val = (input_val - x_zero_point_val) * x_scale_val;
+                sum += @as(f64, @floatCast(dequant_val));
             }
 
             // Calculate average
@@ -138,27 +144,8 @@ pub fn lean_qlinearglobalaveragepool(
             const sum_f32 = @as(f32, @floatCast(sum));
             const avg_float = sum_f32 / spatial_size_f32;
 
-            // Quantize result
-            const scaled_result = (avg_float / y_scale_val) + @as(f32, @floatFromInt(y_zero_point_val));
-
-            // Clamp to valid range for output type
-            const OutputType = @TypeOf(output.data[0]);
-            const min_val = if (@typeInfo(OutputType) == .int)
-                @as(f32, @floatFromInt(std.math.minInt(OutputType)))
-            else
-                std.math.floatMin(OutputType);
-            const max_val = if (@typeInfo(OutputType) == .int)
-                @as(f32, @floatFromInt(std.math.maxInt(OutputType)))
-            else
-                std.math.floatMax(OutputType);
-            const clamped_result = std.math.clamp(scaled_result, min_val, max_val);
-
-            // Store result
             const output_idx = (n * channels) + c;
-            output.data[output_idx] = if (@typeInfo(OutputType) == .int)
-                @as(OutputType, @intFromFloat(clamped_result))
-            else
-                @as(OutputType, clamped_result);
+            out_tensor.data[output_idx] = avg_float;
         }
     }
 }

--- a/src/IR_zant/op_union/operators/op_qlinearglobalaveragepool.zig
+++ b/src/IR_zant/op_union/operators/op_qlinearglobalaveragepool.zig
@@ -26,7 +26,7 @@ const utils = IR_zant.utils;
 //      - Y_scale (heterogeneous) - tensor(float): Scale of quantization of output Y
 //      - Y_zero_point (heterogeneous) - T: Zero point of quantization of output Y
 // OUTPUTS:
-//      - Y (heterogeneous) - T: Output tensor (quantized)
+//      - Y (heterogeneous) - tensor(float): Dequantized output tensor
 
 pub const QLinearGlobalAveragePool = struct {
     input_X: *TensorZant,
@@ -50,8 +50,12 @@ pub const QLinearGlobalAveragePool = struct {
 
         const output_Y = if (tensorZant_lib.tensorMap.getPtr(nodeProto.output[0])) |ptr| ptr else return error.output_Y_notFound;
 
-        //set the output type:
-        if (output_Y.ty == tensorZant_lib.TensorType.undefined) output_Y.ty = input_X.ty;
+        // QLinearGlobalAveragePool produces float32 averages regardless of input type
+        if (output_Y.ty == tensorZant_lib.TensorType.undefined) {
+            output_Y.ty = tensorZant_lib.TensorType.f32;
+        } else if (output_Y.ty != tensorZant_lib.TensorType.f32) {
+            return error.InvalidOutputType;
+        }
 
         const qlinear_gap = QLinearGlobalAveragePool{
             .input_X = input_X,


### PR DESCRIPTION
## Summary
- make the tensor math QLinearGlobalAveragePool implementation allocate float32 tensors, dequantize inputs, and emit dequantized averages
- require the IR QLinearGlobalAveragePool node to advertise an f32 output tensor so generated code passes a float buffer to the math helper
- restore GlobalAveragePool to its original element-type-preserving implementation so only the quantized global variant produces float outputs

## Testing
- zig fmt src/Core/Tensor/TensorMath/op_qlinearglobalaveragepool.zig src/IR_zant/op_union/operators/op_qlinearglobalaveragepool.zig *(fails: `zig` is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17bae3ddc83268e755ea8f6f369cb