### PR TITLE
fix(TensorMath): clamp q16 output to i32 bounds to prevent overflow

### DIFF
--- a/src/Core/Tensor/TensorMath/op_qlinearconv.zig
+++ b/src/Core/Tensor/TensorMath/op_qlinearconv.zig
@@ -102,7 +102,15 @@ fn readPerChannelZPInternal(zp_any: anytype, m: usize) i32 {
 
 const SHIFT: u5 = 16;
 inline fn q16(x: f32) i32 {
-    return @as(i32, @intFromFloat(x * @as(f32, @floatFromInt(@as(u32, 1) << SHIFT))));
+    const scaled = x * @as(f32, @floatFromInt(@as(u32, 1) << SHIFT));
+    // Clamp to i32 bounds to prevent overflow
+    if (scaled > @as(f32, @floatFromInt(std.math.maxInt(i32)))) {
+        return std.math.maxInt(i32);
+    }
+    if (scaled < @as(f32, @floatFromInt(std.math.minInt(i32)))) {
+        return std.math.minInt(i32);
+    }
+    return @as(i32, @intFromFloat(scaled));
 }
 
 inline fn rshift_round_s64(x: i64, comptime shift_bits: u5) i64 {


### PR DESCRIPTION
- Added clamping logic in `q16` function to ensure output remains within i32 limits.

# Pull Request Template

## Description

Please provide a clear and concise description of the changes made in this pull request. Explain the problem this PR solves or the feature it adds.

**Related Issue:** Closes #issue_number

## Type of Change

Please mark the options that are relevant:

- [ ] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Documentation update 📚
- [ ] Other (please describe):

## Checklist

- [ ] My code follows the project's coding style guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass.

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

## Screenshots (if applicable)

If applicable, add screenshots to help explain your changes.

## Additional Information

Add any other context or information about the pull request here.
