### PR TITLE
fix: update shebang in `zant` script for portability

### DIFF
--- a/zant
+++ b/zant
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # zant - A shell wrapper for ONNX Python tools
 # Usage: ./zant <script> [flags]


### PR DESCRIPTION
## Description

Even on newer versions of macOS `/bin/bash` is still in the range 3.x which means no support for associative arrays - feature used in `zant` [here](https://github.com/ZantFoundation/Z-Ant/blob/96a22f93c1038fc54645079f1fba6a7f3d65f35e/zant#L8-L11). Usually a newer (>4.0) `bash` installation is available on the system and specified in ENV.

Therefore I'd argue the proposed change ensures the `zant` bash script is more portable.

## Type of Change

Please mark the options that are relevant:

- [x] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Documentation update 📚
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass.

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

## Additional Information

Execution error reported on `macos 26` before the change:
```
./zant: line 9: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
```