### PR TITLE
docs(ZANT_CLI): fix trivial typo

### DIFF
--- a/docs/ZANT_CLI.md
+++ b/docs/ZANT_CLI.md
@@ -82,7 +82,7 @@ zig build extractor-test -Dmodel=mnist-8
 | `-Dop` | string | `"all"` | Specific operation name to test | Both oneop commands |
 
 ### OneOp Usage Examples
-Remember to fist generate the onnx with the onnx_generator.py see [here](#2-test-single-operations)
+Remember to first generate the onnx with the onnx_generator.py see [here](#2-test-single-operations)
 ```bash
 # Generate tests for all operations listed in available_operations.txt
 zig build op-codegen-gen


### PR DESCRIPTION
## Description

Trivial typo fix in ZANT_CLI.md

s/fist/first/

## Type of Change

Please mark the options that are relevant:

- [ ] Bug fix 🐛
- [ ] New feature 🚀
- [x] Documentation update 📚
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass.

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

Just read the text

## Screenshots (if applicable)

If applicable, add screenshots to help explain your changes.

## Additional Information

Add any other context or information about the pull request here.
